### PR TITLE
Add route annotator and line marker provider

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -47,6 +47,8 @@
 <ul>
   <li>completion for backend route names on BackendUtility::getAjaxUrl()</li>
   <li>completion for backend route names on UriBuilder::buildUriFromRoute()</li>
+  <li>annotations for both valid and invalid route references</li>
+  <li>line marker to allow quick navigation to the route definition</li>
 </ul>
 
 <h2>Credits</h2>

--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -106,6 +106,12 @@ It is a great inspiration for possible solutions and parts of the code.</p>
 
     <!-- completion -->
     <completion.contributor language="PHP" implementationClass="com.cedricziel.idea.typo3.codeInsight.RoutesCompletionContributor"/>
+
+    <!-- annotation -->
+    <annotator language="PHP" implementationClass="com.cedricziel.idea.typo3.annotation.RouteAnnotator"/>
+
+    <!-- marker -->
+    <codeInsight.lineMarkerProvider language="PHP" implementationClass="com.cedricziel.idea.typo3.codeInsight.RouteLineMarkerProvider"/>
   </extensions>
 
   <extensions defaultExtensionNs="com.jetbrains.php">

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ On PhpStorm or IntelliJ:
 * TypeProvider for `GeneralUtility::makeInstanceService`
 * TypeProvider for `ObjectManager::get`
 * CompletionContributor for `UriBuilder::buildUriFromRoute` and `BackendUtility::getAjaxUrl`
+* Annotator for both valid and invalid route references to make them distinguishable from normal strings
+* LineMarkerProvider to allow quick navigation to the route definition
 
 ## Credits
 

--- a/src/com/cedricziel/idea/typo3/annotation/RouteAnnotator.java
+++ b/src/com/cedricziel/idea/typo3/annotation/RouteAnnotator.java
@@ -1,0 +1,65 @@
+package com.cedricziel.idea.typo3.annotation;
+
+import com.cedricziel.idea.typo3.container.RouteProvider;
+import com.cedricziel.idea.typo3.psi.PhpElementsUtil;
+import com.intellij.lang.annotation.Annotation;
+import com.intellij.lang.annotation.AnnotationHolder;
+import com.intellij.lang.annotation.Annotator;
+import com.intellij.openapi.editor.DefaultLanguageHighlighterColors;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.jetbrains.php.lang.psi.elements.MethodReference;
+import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
+import org.jetbrains.annotations.NotNull;
+
+public class RouteAnnotator implements Annotator {
+    @Override
+    public void annotate(@NotNull PsiElement psiElement, @NotNull AnnotationHolder annotationHolder) {
+
+        if (!(psiElement instanceof StringLiteralExpression)) {
+            return;
+        }
+
+        StringLiteralExpression literalExpression = (StringLiteralExpression) psiElement;
+        String value = literalExpression.getContents();
+
+        if (value.isEmpty()) {
+            return;
+        }
+
+        PsiElement methodReference = PsiTreeUtil.getParentOfType(psiElement, MethodReference.class);
+        if (PhpElementsUtil.isMethodWithFirstStringOrFieldReference(methodReference, "getAjaxUrl")) {
+            annotateAjaxRoutes(psiElement, annotationHolder, value);
+        }
+        if (PhpElementsUtil.isMethodWithFirstStringOrFieldReference(methodReference, "buildUriFromRoute")) {
+            annotateRoutes(psiElement, annotationHolder, value);
+        }
+    }
+
+    private void annotateAjaxRoutes(PsiElement psiElement, AnnotationHolder annotationHolder, String value) {
+        RouteProvider routeProvider = new RouteProvider();
+        routeProvider.collect(psiElement.getProject());
+
+        annotateRoute(psiElement, annotationHolder, value, routeProvider, RouteProvider.ROUTE_TYPE_AJAX);
+    }
+
+    private void annotateRoutes(PsiElement psiElement, AnnotationHolder annotationHolder, String value) {
+        RouteProvider routeProvider = new RouteProvider();
+        routeProvider.collect(psiElement.getProject());
+
+        annotateRoute(psiElement, annotationHolder, value, routeProvider, RouteProvider.ROUTE_TYPE_BACKEND);
+    }
+
+
+    private void annotateRoute(PsiElement psiElement, AnnotationHolder annotationHolder, String value, RouteProvider routeProvider, String routeType) {
+        if (routeProvider.has(value, routeType)) {
+            TextRange range = new TextRange(psiElement.getTextRange().getStartOffset(), psiElement.getTextRange().getEndOffset());
+            Annotation annotation = annotationHolder.createInfoAnnotation(range, null);
+            annotation.setTextAttributes(DefaultLanguageHighlighterColors.LINE_COMMENT);
+        } else {
+            TextRange range = new TextRange(psiElement.getTextRange().getStartOffset(), psiElement.getTextRange().getEndOffset());
+            annotationHolder.createErrorAnnotation(range, "Unresolved route");
+        }
+    }
+}

--- a/src/com/cedricziel/idea/typo3/codeInsight/RouteLineMarkerProvider.java
+++ b/src/com/cedricziel/idea/typo3/codeInsight/RouteLineMarkerProvider.java
@@ -1,0 +1,57 @@
+package com.cedricziel.idea.typo3.codeInsight;
+
+import com.cedricziel.idea.typo3.TYPO3CMSIcons;
+import com.cedricziel.idea.typo3.container.RouteProvider;
+import com.cedricziel.idea.typo3.domain.TYPO3RouteDefinition;
+import com.cedricziel.idea.typo3.psi.PhpElementsUtil;
+import com.intellij.codeInsight.daemon.RelatedItemLineMarkerInfo;
+import com.intellij.codeInsight.daemon.RelatedItemLineMarkerProvider;
+import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.jetbrains.php.lang.psi.elements.MethodReference;
+import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.List;
+
+public class RouteLineMarkerProvider extends RelatedItemLineMarkerProvider {
+    @Override
+    protected void collectNavigationMarkers(@NotNull PsiElement element, Collection<? super RelatedItemLineMarkerInfo> result) {
+
+        if (!(element instanceof StringLiteralExpression)) {
+            return;
+        }
+
+        StringLiteralExpression literalExpression = (StringLiteralExpression) element;
+        String value = literalExpression.getContents();
+
+        if (value.isEmpty()) {
+            return;
+        }
+
+        PsiElement methodReference = PsiTreeUtil.getParentOfType(element, MethodReference.class);
+        if (PhpElementsUtil.isMethodWithFirstStringOrFieldReference(methodReference, "getAjaxUrl") || PhpElementsUtil.isMethodWithFirstStringOrFieldReference(methodReference, "buildUriFromRoute")) {
+
+            Project project = element.getProject();
+
+            RouteProvider routeProvider = new RouteProvider();
+            routeProvider.collect(project);
+
+            if (routeProvider.has(value)) {
+                List<TYPO3RouteDefinition> definitions = routeProvider.resolve(value);
+                definitions.forEach(def -> {
+                    NavigationGutterIconBuilder<PsiElement> builder = NavigationGutterIconBuilder
+                            .create(TYPO3CMSIcons.ROUTE_ICON)
+                            .setTarget(def.getElement())
+                            .setTooltipText("Navigate to route definition");
+
+                    result.add(builder.createLineMarkerInfo(element));
+                });
+
+            }
+        }
+    }
+}

--- a/src/com/cedricziel/idea/typo3/container/RouteProvider.java
+++ b/src/com/cedricziel/idea/typo3/container/RouteProvider.java
@@ -56,12 +56,28 @@ public class RouteProvider {
         collectRoutes(project);
     }
 
-    public Boolean has(Project project, String routeName) {
-        return null;
+    public Boolean has(String routeName) {
+        return routes.containsKey(routeName) || ajaxRoutes.containsKey(routeName);
+    }
+
+    public Boolean has(String routeName, String type) {
+        if (type.equals(ROUTE_TYPE_BACKEND)) {
+            return routes.containsKey(routeName);
+        } else {
+            return ajaxRoutes.containsKey(routeName);
+        }
     }
 
     public List<TYPO3RouteDefinition> resolve(String routeName) {
-        return null;
+        List<TYPO3RouteDefinition> list = new ArrayList<>();
+        if(ajaxRoutes.containsKey(routeName)) {
+            ajaxRoutes.get(routeName).forEach(list::add);
+        }
+        if(routes.containsKey(routeName)) {
+            routes.get(routeName).forEach(list::add);
+        }
+
+        return list;
     }
 
     public List<TYPO3RouteDefinition> all() {

--- a/src/com/cedricziel/idea/typo3/domain/TYPO3RouteDefinition.java
+++ b/src/com/cedricziel/idea/typo3/domain/TYPO3RouteDefinition.java
@@ -1,11 +1,14 @@
 package com.cedricziel.idea.typo3.domain;
 
+import com.intellij.psi.PsiElement;
+
 public class TYPO3RouteDefinition {
     private String name;
     private String path;
     private String access;
     private String target;
     private String type;
+    private PsiElement element;
 
     public String getName() {
         return name;
@@ -45,5 +48,13 @@ public class TYPO3RouteDefinition {
 
     public String getType() {
         return type;
+    }
+
+    public void setElement(PsiElement element) {
+        this.element = element;
+    }
+
+    public PsiElement getElement() {
+        return element;
     }
 }

--- a/src/com/cedricziel/idea/typo3/psi/visitor/RouteDefinitionParserVisitor.java
+++ b/src/com/cedricziel/idea/typo3/psi/visitor/RouteDefinitionParserVisitor.java
@@ -78,6 +78,7 @@ public class RouteDefinitionParserVisitor extends PsiRecursiveElementVisitor {
 
                     routeDefinition.setName(key);
                     routeDefinition.setType(type);
+                    routeDefinition.setElement(valueMap);
 
                     for (ArrayHashElement routePropertyHashElement : propertyArray.getHashElements()) {
                         String propertyName = ((StringLiteralExpression) routePropertyHashElement.getKey()).getContents();


### PR DESCRIPTION
The annotator marks valid and invalid route references visually:

![arbeitsflache 1_022](https://cloud.githubusercontent.com/assets/418970/23215160/b5225300-f911-11e6-8f06-5d477f75def5.jpg)

The marker provider marks the line with the literal epression and allows the user to jump directly to the definition:

![arbeitsflache 1_024](https://cloud.githubusercontent.com/assets/418970/23215174/bca8cec4-f911-11e6-9eec-45d288b4bf44.jpg)

