### PR TITLE
Add warning instead of an error on missing icons

### DIFF
--- a/src/com/cedricziel/idea/typo3/annotation/IconAnnotator.java
+++ b/src/com/cedricziel/idea/typo3/annotation/IconAnnotator.java
@@ -46,7 +46,7 @@ public class IconAnnotator implements Annotator {
             annotation.setTextAttributes(DefaultLanguageHighlighterColors.LINE_COMMENT);
         } else {
             TextRange range = new TextRange(psiElement.getTextRange().getStartOffset(), psiElement.getTextRange().getEndOffset());
-            annotationHolder.createErrorAnnotation(range, "Unresolved icon");
+            annotationHolder.createWarningAnnotation(range, "Unresolved icon");
         }
     }
 }

--- a/src/com/cedricziel/idea/typo3/annotation/IconAnnotator.java
+++ b/src/com/cedricziel/idea/typo3/annotation/IconAnnotator.java
@@ -46,7 +46,7 @@ public class IconAnnotator implements Annotator {
             annotation.setTextAttributes(DefaultLanguageHighlighterColors.LINE_COMMENT);
         } else {
             TextRange range = new TextRange(psiElement.getTextRange().getStartOffset(), psiElement.getTextRange().getEndOffset());
-            annotationHolder.createWarningAnnotation(range, "Unresolved icon");
+            annotationHolder.createWarningAnnotation(range, "Unresolved icon - this may also occur if the icon is defined in your extension, but not in the global icon registry.");
         }
     }
 }


### PR DESCRIPTION
Icons added in an extensions currently can't be resolved, so it would be nicer to trigger a warning instead of an error.