### PR TITLE
[T3CMS] Contribute Signal/Slot References to slot methods

### DIFF
--- a/typo3-cms/src/main/java/com/cedricziel/idea/typo3/TYPO3CMSIcons.java
+++ b/typo3-cms/src/main/java/com/cedricziel/idea/typo3/TYPO3CMSIcons.java
@@ -8,4 +8,5 @@ public interface TYPO3CMSIcons {
     Icon TYPO3_ICON = IconLoader.getIcon("/icons/dist/icon-typo3.png");
     Icon ROUTE_ICON = IconLoader.getIcon("/icons/dist/icon-navigate-route-definition.png");
     Icon ICON_NOT_RESOLVED = IconLoader.getIcon("/icons/dist/icon-icon-not-resolved.png");
+    Icon SIGNAL_COMPLETED_METHOD = IconLoader.getIcon("/icons/dist/icon-typo3.png");
 }

--- a/typo3-cms/src/main/java/com/cedricziel/idea/typo3/TYPO3Patterns.java
+++ b/typo3-cms/src/main/java/com/cedricziel/idea/typo3/TYPO3Patterns.java
@@ -1,0 +1,25 @@
+package com.cedricziel.idea.typo3;
+
+import com.intellij.patterns.ElementPattern;
+import com.intellij.patterns.PlatformPatterns;
+import com.intellij.psi.PsiElement;
+import com.jetbrains.php.lang.psi.elements.MethodReference;
+import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
+
+public class TYPO3Patterns {
+    /*
+     * \TYPO3\CMS\Extbase\SignalSlot\Dispatcher::class->connect(,,,'<caret>')
+     */
+    public static ElementPattern<? extends PsiElement> connectSignalMethodName() {
+        return PlatformPatterns
+            .psiElement().withParent(
+                PlatformPatterns.psiElement(StringLiteralExpression.class)
+            )
+            .withSuperParent(3, PlatformPatterns.psiElement(MethodReference.class));
+    }
+
+    public static ElementPattern<? extends PsiElement> connectSignalMethodNameString() {
+        return PlatformPatterns.psiElement(StringLiteralExpression.class)
+            .withSuperParent(2, PlatformPatterns.psiElement(MethodReference.class));
+    }
+}

--- a/typo3-cms/src/main/java/com/cedricziel/idea/typo3/dispatcher/SignalDispatcherReferenceContributor.java
+++ b/typo3-cms/src/main/java/com/cedricziel/idea/typo3/dispatcher/SignalDispatcherReferenceContributor.java
@@ -1,0 +1,64 @@
+package com.cedricziel.idea.typo3.dispatcher;
+
+import com.cedricziel.idea.typo3.TYPO3Patterns;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.*;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.util.ProcessingContext;
+import com.jetbrains.php.lang.psi.elements.ClassConstantReference;
+import com.jetbrains.php.lang.psi.elements.ParameterList;
+import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class SignalDispatcherReferenceContributor extends PsiReferenceContributor {
+    @Override
+    public void registerReferenceProviders(@NotNull PsiReferenceRegistrar registrar) {
+
+        registrar.registerReferenceProvider(
+            TYPO3Patterns.connectSignalMethodNameString(),
+            new PsiReferenceProvider() {
+                @NotNull
+                @Override
+                public PsiReference[] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
+                    StringLiteralExpression subject = (StringLiteralExpression) element;
+                    ParameterList parameterList = (ParameterList) PsiTreeUtil.findFirstParent(subject, e -> e instanceof ParameterList);
+                    if (parameterList == null) {
+                        return PsiReference.EMPTY_ARRAY;
+                    }
+
+                    List<PsiElement> parameters = Arrays.asList(parameterList.getParameters());
+                    if (parameters.indexOf(subject) == 3) {
+                        PsiElement className = parameters.get(2);
+                        if (className instanceof ClassConstantReference) {
+                            if (subject.getContents().length() > subject.getText().length()) {
+                                return new SignalSlotMethodReference[]{
+                                    new SignalSlotMethodReference((ClassConstantReference) className, subject, new TextRange(1, subject.getContents().length()))
+                                };
+                            }
+
+                            return new SignalSlotMethodReference[]{
+                                new SignalSlotMethodReference((ClassConstantReference) className, subject)
+                            };
+                        }
+                        if (className instanceof StringLiteralExpression) {
+                            if (subject.getContents().length() > subject.getText().length()) {
+                                return new SignalSlotMethodReference[]{
+                                    new SignalSlotMethodReference((StringLiteralExpression) className, subject, new TextRange(1, subject.getContents().length()))
+                                };
+                            }
+
+                            return new SignalSlotMethodReference[]{
+                                new SignalSlotMethodReference((StringLiteralExpression) className, subject)
+                            };
+                        }
+                    }
+
+                    return PsiReference.EMPTY_ARRAY;
+                }
+            }
+        );
+    }
+}

--- a/typo3-cms/src/main/java/com/cedricziel/idea/typo3/dispatcher/SignalSlotMethodReference.java
+++ b/typo3-cms/src/main/java/com/cedricziel/idea/typo3/dispatcher/SignalSlotMethodReference.java
@@ -1,0 +1,95 @@
+package com.cedricziel.idea.typo3.dispatcher;
+
+import com.cedricziel.idea.typo3.util.SignalSlotDispatcherUtil;
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementResolveResult;
+import com.intellij.psi.PsiPolyVariantReferenceBase;
+import com.intellij.psi.ResolveResult;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.jetbrains.php.lang.psi.elements.ClassConstantReference;
+import com.jetbrains.php.lang.psi.elements.ClassReference;
+import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SignalSlotMethodReference extends PsiPolyVariantReferenceBase<PsiElement> {
+
+    private final String methodName;
+    private final String classFqn;
+
+    public SignalSlotMethodReference(@NotNull ClassConstantReference classConstantReference, @NotNull StringLiteralExpression subject) {
+        super(subject);
+
+        this.methodName = subject.getContents();
+
+        ClassReference classReference = PsiTreeUtil.findChildOfType(classConstantReference, ClassReference.class);
+        if (classReference == null || classReference.getFQN() == null) {
+            classFqn = "";
+            subject.getContents();
+
+            return;
+        }
+
+        this.classFqn = classReference.getFQN();
+    }
+
+    public SignalSlotMethodReference(@NotNull ClassConstantReference classConstantReference, @NotNull StringLiteralExpression subject, TextRange range) {
+        super(subject, range);
+
+        this.methodName = subject.getContents();
+
+        ClassReference classReference = PsiTreeUtil.findChildOfType(classConstantReference, ClassReference.class);
+        if (classReference == null || classReference.getFQN() == null) {
+            classFqn = "";
+
+            return;
+        }
+
+        this.classFqn = classReference.getFQN();
+    }
+
+    public SignalSlotMethodReference(@NotNull StringLiteralExpression className, @NotNull StringLiteralExpression subject) {
+        super(subject);
+
+        this.classFqn = className.getContents();
+        this.methodName = subject.getContents();
+    }
+
+    public SignalSlotMethodReference(@NotNull StringLiteralExpression className, @NotNull StringLiteralExpression subject, TextRange range) {
+        super(subject, range);
+
+        this.classFqn = className.getContents();
+        this.methodName = subject.getContents();
+    }
+
+    @NotNull
+    @Override
+    public ResolveResult[] multiResolve(boolean incompleteCode) {
+        if (classFqn.isEmpty()) {
+            return ResolveResult.EMPTY_ARRAY;
+        }
+
+        List<ResolveResult> results = new ArrayList<>();
+        PsiElement[] psiElements = SignalSlotDispatcherUtil.getSignalPsiElements(myElement.getProject(), classFqn, methodName);
+
+        for (PsiElement psiElement : psiElements) {
+            results.add(new PsiElementResolveResult(psiElement));
+        }
+
+        return results.toArray(new ResolveResult[0]);
+    }
+
+    @NotNull
+    @Override
+    public Object[] getVariants() {
+        if (classFqn.isEmpty()) {
+            return LookupElement.EMPTY_ARRAY;
+        }
+
+        return SignalSlotDispatcherUtil.getPossibleSlotMethodLookupElements(myElement.getProject(), classFqn);
+    }
+}

--- a/typo3-cms/src/main/java/com/cedricziel/idea/typo3/util/SignalSlotDispatcherUtil.java
+++ b/typo3-cms/src/main/java/com/cedricziel/idea/typo3/util/SignalSlotDispatcherUtil.java
@@ -1,0 +1,41 @@
+package com.cedricziel.idea.typo3.util;
+
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.codeInsight.lookup.LookupElementBuilder;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.jetbrains.php.PhpIndex;
+import com.jetbrains.php.lang.psi.elements.Method;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SignalSlotDispatcherUtil {
+    @NotNull
+    public static PsiElement[] getSignalPsiElements(final Project project, String fqn, final String methodName) {
+        List<PsiElement> foundElements = new ArrayList<>();
+
+        PhpIndex.getInstance(project).getClassesByFQN(fqn).forEach(c -> {
+            Method methodByName = c.findMethodByName(methodName);
+            if (methodByName != null) {
+                foundElements.add(methodByName);
+            }
+        });
+
+        return foundElements.toArray(new PsiElement[0]);
+    }
+
+    public static LookupElement[] getPossibleSlotMethodLookupElements(@NotNull Project project, @NotNull String fqn) {
+        List<LookupElement> lookupElements = new ArrayList<>();
+        PhpIndex.getInstance(project).getClassesByFQN(fqn).forEach(c -> {
+            for (Method method : c.getMethods()) {
+                if (method.getModifier().isPublic()) {
+                    lookupElements.add(LookupElementBuilder.createWithIcon(method));
+                }
+            }
+        });
+
+        return lookupElements.toArray(new LookupElement[0]);
+    }
+}

--- a/typo3-cms/src/main/resources/META-INF/plugin.xml
+++ b/typo3-cms/src/main/resources/META-INF/plugin.xml
@@ -221,6 +221,10 @@ It is a great inspiration for possible solutions and parts of the code.</p>
 
         <!-- userFunc -->
         <psi.referenceContributor implementation="com.cedricziel.idea.typo3.userFunc.UserFuncReferenceContributor"/>
+
+        <!-- signal / slot -->
+        <psi.referenceContributor language="PHP"
+                                  implementation="com.cedricziel.idea.typo3.dispatcher.SignalDispatcherReferenceContributor"/>
     </extensions>
 
     <actions>

--- a/typo3-cms/src/test/java/com/cedricziel/idea/typo3/dispatcher/SignalDispatcherReferenceContributorTest.java
+++ b/typo3-cms/src/test/java/com/cedricziel/idea/typo3/dispatcher/SignalDispatcherReferenceContributorTest.java
@@ -1,0 +1,84 @@
+package com.cedricziel.idea.typo3.dispatcher;
+
+import com.cedricziel.idea.typo3.AbstractTestCase;
+import com.intellij.psi.PsiElement;
+import com.jetbrains.php.lang.PhpFileType;
+import com.jetbrains.php.lang.psi.elements.Method;
+
+import java.util.List;
+
+public class SignalDispatcherReferenceContributorTest extends AbstractTestCase {
+    @Override
+    protected String getTestDataPath() {
+        return "testData/com/cedricziel/idea/typo3/dispatcher";
+    }
+
+    public void testReferenceCanBeResolvedWithClassConstantReference() {
+        myFixture.copyFileToProject("classes.php");
+
+        configureSignalSlotConnect(
+            "\\TYPO3\\CMS\\Core\\Core\\ClassLoadingInformation::class",
+            "'dumpClassLoadingInformat<caret>ion'"
+        );
+
+        PsiElement elementAtCaret = myFixture.getElementAtCaret();
+        assertNotNull(elementAtCaret);
+        assertInstanceOf(elementAtCaret, Method.class);
+        assertEquals("dumpClassLoadingInformation", ((Method) elementAtCaret).getName());
+    }
+
+    public void testReferenceCanBeResolvedWithStringClassReference() {
+        myFixture.copyFileToProject("classes.php");
+
+        configureSignalSlotConnect(
+            "'\\TYPO3\\CMS\\Core\\Core\\ClassLoadingInformation'",
+            "'dumpClassLoadingInformat<caret>ion'"
+        );
+
+        PsiElement elementAtCaret = myFixture.getElementAtCaret();
+        assertNotNull(elementAtCaret);
+        assertInstanceOf(elementAtCaret, Method.class);
+        assertEquals("dumpClassLoadingInformation", ((Method) elementAtCaret).getName());
+    }
+
+    private void configureSignalSlotConnect(String classParameters, String methodParameter) {
+        myFixture.configureByText(PhpFileType.INSTANCE, "<?php\n" +
+            "/** @var \\TYPO3\\CMS\\Extbase\\SignalSlot\\Dispatcher $signalSlotDispatcher */\n" +
+            "$signalSlotDispatcher = \\TYPO3\\CMS\\Core\\Utility\\GeneralUtility::makeInstance(\\TYPO3\\CMS\\Extbase\\SignalSlot\\Dispatcher::class);\n" +
+            "$signalSlotDispatcher->connect(\n" +
+            "    \\TYPO3\\CMS\\Extensionmanager\\Utility\\InstallUtility::class,  // Signal class name\n" +
+            "    'foo',                                                           // Signal name\n" +
+            "    " + classParameters + ",                                         // Slot class name\n" +
+            "    " + methodParameter + "                                          // Slot name\n" +
+            ");"
+        );
+    }
+
+    public void testCanProvideVariantsWithClassConstantReference() {
+        myFixture.copyFileToProject("classes.php");
+
+        configureSignalSlotConnect("\\TYPO3\\CMS\\Core\\Core\\ClassLoadingInformation::class", "'<caret>'");
+
+        myFixture.completeBasic();
+
+        List<String> lookupElementStrings = myFixture.getLookupElementStrings();
+        assertTrue(lookupElementStrings.contains("dumpClassLoadingInformation"));
+        assertTrue(lookupElementStrings.contains("anotherOne"));
+        assertFalse(lookupElementStrings.contains("aPrivateOne"));
+        assertFalse(lookupElementStrings.contains("aProtectedOne"));
+    }
+
+    public void testCanProvideVariantsWithStringClassReference() {
+        myFixture.copyFileToProject("classes.php");
+
+        configureSignalSlotConnect("'\\TYPO3\\CMS\\Core\\Core\\ClassLoadingInformation'", "'<caret>'");
+
+        myFixture.completeBasic();
+
+        List<String> lookupElementStrings = myFixture.getLookupElementStrings();
+        assertTrue(lookupElementStrings.contains("dumpClassLoadingInformation"));
+        assertTrue(lookupElementStrings.contains("anotherOne"));
+        assertFalse(lookupElementStrings.contains("aPrivateOne"));
+        assertFalse(lookupElementStrings.contains("aProtectedOne"));
+    }
+}

--- a/typo3-cms/testData/com/cedricziel/idea/typo3/dispatcher/classes.php
+++ b/typo3-cms/testData/com/cedricziel/idea/typo3/dispatcher/classes.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace TYPO3\CMS\Extbase\SignalSlot {
+    class Dispatcher
+    {
+        public function connect()
+        {
+
+        }
+    }
+}
+
+namespace TYPO3\CMS\Core\Core {
+    class ClassLoadingInformation
+    {
+        public function dumpClassLoadingInformation()
+        {
+
+        }
+
+        public function anotherOne()
+        {
+
+        }
+
+        private function aPrivateOne()
+        {
+
+        }
+
+        private function aProtectedOne()
+        {
+
+        }
+    }
+}


### PR DESCRIPTION
Allows seamless navigation between slot methods and their reference.

Enables stable, name-based refactoring of slot method names.

Closes: #55
Closes: #67