### PR TITLE
Add support for `EXT:foo/bar/..` syntax

### DIFF
--- a/src/main/java/com/cedricziel/idea/typo3/annotation/PathResourceAnnotator.java
+++ b/src/main/java/com/cedricziel/idea/typo3/annotation/PathResourceAnnotator.java
@@ -1,0 +1,84 @@
+package com.cedricziel.idea.typo3.annotation;
+
+import com.intellij.lang.annotation.AnnotationHolder;
+import com.intellij.lang.annotation.Annotator;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.search.FilenameIndex;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
+import org.codehaus.plexus.util.DirectoryScanner;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Matches {@link StringLiteralExpression} elements and annotates them if a resource does not exist.
+ * <p>
+ * Example strings:
+ * "EXT:foo/bar/baz.typoscript"
+ */
+public class PathResourceAnnotator implements Annotator {
+    @Override
+    public void annotate(@NotNull PsiElement element, @NotNull AnnotationHolder holder) {
+        if (!(element instanceof StringLiteralExpression)) {
+            return;
+        }
+
+        String content = ((StringLiteralExpression) element).getContents();
+        if (!content.startsWith("EXT:") || element.getProject().getBasePath() == null) {
+            return;
+        }
+
+        String resourceName = content.substring(4, content.length());
+        if (resourceName.contains(":")) {
+            // resource name points to a sub-resource such as a translation string, not here.
+            return;
+        }
+
+        String[] split = resourceName.split("/");
+        String fileName = split[split.length - 1];
+        DirectoryScanner scanner = new DirectoryScanner();
+
+        scanner.setBasedir(element.getProject().getBasePath());
+        scanner.addDefaultExcludes();
+        scanner.setIncludes(new String[]{"**/" + resourceName + "/"});
+        scanner.scan();
+
+        String[] paths = scanner.getIncludedFiles();
+        if (paths.length != 0) {
+            // the resource is a directory
+            return;
+        }
+
+        List<PsiFile> filesByName = Arrays.asList(FilenameIndex.getFilesByName(element.getProject(), fileName, GlobalSearchScope.allScope(element.getProject())));
+        if (filesByName.size() == 0) {
+            createErrorMessage(element, holder, resourceName);
+
+            return;
+        }
+
+        for (PsiFile file : filesByName) {
+            VirtualFile virtualFile = file.getVirtualFile();
+
+
+            if (virtualFile.getPath().contains("typo3conf/ext/" + resourceName) || virtualFile.getPath().contains("sysext/" + resourceName)) {
+                // all good
+                return;
+            }
+
+            if (virtualFile.isDirectory() && virtualFile.getPath().endsWith(resourceName)) {
+                return;
+            }
+        }
+
+        createErrorMessage(element, holder, resourceName);
+    }
+
+    private void createErrorMessage(@NotNull PsiElement element, @NotNull AnnotationHolder holder, String resourceName) {
+        String message = "Resource \"%s\" could not be found in your current project.".replace("%s", resourceName);
+        holder.createErrorAnnotation(element, message);
+    }
+}

--- a/src/main/java/com/cedricziel/idea/typo3/codeInsight/PathResourceCompletionContributor.java
+++ b/src/main/java/com/cedricziel/idea/typo3/codeInsight/PathResourceCompletionContributor.java
@@ -1,0 +1,116 @@
+package com.cedricziel.idea.typo3.codeInsight;
+
+import com.intellij.codeInsight.completion.*;
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.codeInsight.lookup.LookupElementPresentation;
+import com.intellij.icons.AllIcons;
+import com.intellij.openapi.project.Project;
+import com.intellij.patterns.PlatformPatterns;
+import com.intellij.psi.PsiElement;
+import com.intellij.util.ProcessingContext;
+import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
+import org.codehaus.plexus.util.DirectoryScanner;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+
+public class PathResourceCompletionContributor extends CompletionContributor {
+    public PathResourceCompletionContributor() {
+        extend(
+                CompletionType.BASIC,
+                PlatformPatterns.psiElement().withParent(PlatformPatterns.psiElement(StringLiteralExpression.class)),
+                new CompletionProvider<CompletionParameters>() {
+                    @Override
+                    protected void addCompletions(@NotNull CompletionParameters parameters, ProcessingContext context, @NotNull CompletionResultSet result) {
+                        PsiElement position = parameters.getPosition();
+
+                        Project project = position.getProject();
+                        PsiElement parent = position.getParent();
+                        if (!(parent instanceof StringLiteralExpression)) {
+                            return;
+                        }
+
+                        String currentText = parent.getText();
+                        if (project.getBasePath() == null || !currentText.contains("EXT:")) {
+                            return;
+                        }
+
+                        String[] includes;
+                        if (currentText.contains("/")) {
+                            String current = currentText
+                                    .split("/", 1)[0]
+                                    .replace("EXT:", "")
+                                    .replace("IntellijIdeaRulezzz", "")
+                                    .replace("'", "")
+                                    .trim();
+
+                            includes = new String[]{
+                                    "**/sysext/" + current + "**",
+                                    "**/typo3conf/ext/" + current + "**",
+                            };
+                        } else {
+                            includes = new String[]{
+                                    "**/sysext/*/",
+                                    "**/typo3conf/ext/*/",
+                            };
+                        }
+
+                        DirectoryScanner scanner = new DirectoryScanner();
+
+                        scanner.setBasedir(project.getBasePath());
+                        scanner.addDefaultExcludes();
+                        scanner.setIncludes(includes);
+                        scanner.scan();
+
+                        Arrays.stream(scanner.getIncludedFiles()).forEach(f -> {
+                            result.addElement(new LookupElement() {
+                                @NotNull
+                                @Override
+                                public String getLookupString() {
+                                    String[] splitted = f.split("sysext/");
+                                    if (splitted.length > 1) {
+                                        return "EXT:" + splitted[1];
+                                    }
+
+                                    splitted = f.split("typo3conf/ext/");
+                                    if (splitted.length > 1) {
+                                        return "EXT:" + splitted[1];
+                                    }
+
+                                    return "EXT:" + f;
+                                }
+                            });
+                        });
+
+                        Arrays.stream(scanner.getIncludedDirectories()).forEach(f -> {
+                            result.addElement(new LookupElement() {
+
+                                @Override
+                                public void renderElement(LookupElementPresentation presentation) {
+                                    presentation.setIcon(AllIcons.Modules.SourceFolder);
+
+                                    super.renderElement(presentation);
+                                }
+
+                                @NotNull
+                                @Override
+                                public String getLookupString() {
+                                    String[] splitted = f.split("sysext/");
+                                    if (splitted.length > 1) {
+                                        return "EXT:" + splitted[1];
+                                    }
+
+                                    splitted = f.split("typo3conf/ext/");
+                                    if (splitted.length > 1) {
+                                        return "EXT:" + splitted[1];
+                                    }
+
+                                    return "EXT:" + f;
+                                }
+                            });
+                        });
+                    }
+                }
+        );
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -275,6 +275,7 @@ It is a great inspiration for possible solutions and parts of the code.</p>
         <!-- annotation -->
         <annotator language="PHP" implementationClass="com.cedricziel.idea.typo3.annotation.IconAnnotator"/>
         <annotator language="PHP" implementationClass="com.cedricziel.idea.typo3.annotation.RouteAnnotator"/>
+        <annotator language="PHP" implementationClass="com.cedricziel.idea.typo3.annotation.PathResourceAnnotator"/>
 
         <!-- marker -->
         <codeInsight.lineMarkerProvider language="PHP"

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -271,6 +271,9 @@ It is a great inspiration for possible solutions and parts of the code.</p>
                                 implementationClass="com.cedricziel.idea.typo3.persistence.codeInsight.DoctrineTablesCompletionContributor"/>
         <completion.contributor language="PHP"
                                 implementationClass="com.cedricziel.idea.typo3.tca.codeInsight.TCACompletionContributor"/>
+        <completion.contributor language="PHP"
+                                implementationClass="com.cedricziel.idea.typo3.codeInsight.PathResourceCompletionContributor"/>
+
 
         <!-- annotation -->
         <annotator language="PHP" implementationClass="com.cedricziel.idea.typo3.annotation.IconAnnotator"/>


### PR DESCRIPTION
Every PHP String now supports the `EXT:` file Syntax and the IDE will autocomplete the path.