### PR TITLE
Introduce PathResourceGotoDeclarationHandler

### DIFF
--- a/src/main/java/com/cedricziel/idea/typo3/codeInsight/PathResourceCompletionContributor.java
+++ b/src/main/java/com/cedricziel/idea/typo3/codeInsight/PathResourceCompletionContributor.java
@@ -23,12 +23,8 @@ public class PathResourceCompletionContributor extends CompletionContributor {
                     @Override
                     protected void addCompletions(@NotNull CompletionParameters parameters, ProcessingContext context, @NotNull CompletionResultSet result) {
                         PsiElement position = parameters.getPosition();
-
                         Project project = position.getProject();
                         PsiElement parent = position.getParent();
-                        if (!(parent instanceof StringLiteralExpression)) {
-                            return;
-                        }
 
                         String currentText = parent.getText();
                         if (project.getBasePath() == null || !currentText.contains("EXT:")) {

--- a/src/main/java/com/cedricziel/idea/typo3/codeInsight/navigation/PathResourceGotoDeclarationHandler.java
+++ b/src/main/java/com/cedricziel/idea/typo3/codeInsight/navigation/PathResourceGotoDeclarationHandler.java
@@ -1,0 +1,51 @@
+package com.cedricziel.idea.typo3.codeInsight.navigation;
+
+import com.intellij.codeInsight.navigation.actions.GotoDeclarationHandler;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.search.FilenameIndex;
+import com.intellij.psi.search.GlobalSearchScope;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.cedricziel.idea.typo3.util.ResourceUtil.isExtResourcePath;
+
+public class PathResourceGotoDeclarationHandler implements GotoDeclarationHandler {
+    @Nullable
+    @Override
+    public PsiElement[] getGotoDeclarationTargets(@Nullable PsiElement sourceElement, int offset, Editor editor) {
+        if (!isExtResourcePath(sourceElement)) {
+            return new PsiElement[0];
+        }
+
+        if (sourceElement != null) {
+            String text = sourceElement.getText();
+            String fileName = text.split("/")[text.split("/").length - 1];
+            String relativePath = text.replaceFirst("EXT:", "");
+
+            List<PsiFile> psiFiles = Arrays.asList(
+                    FilenameIndex.getFilesByName(
+                            sourceElement.getProject(),
+                            fileName,
+                            GlobalSearchScope.allScope(sourceElement.getProject())
+                    ));
+
+            return psiFiles
+                    .stream()
+                    .filter(x -> x.getVirtualFile().getPath().contains(relativePath))
+                    .toArray(PsiElement[]::new);
+        }
+
+        return new PsiElement[0];
+    }
+
+    @Nullable
+    @Override
+    public String getActionText(DataContext context) {
+        return null;
+    }
+}

--- a/src/main/java/com/cedricziel/idea/typo3/util/ResourceUtil.java
+++ b/src/main/java/com/cedricziel/idea/typo3/util/ResourceUtil.java
@@ -1,0 +1,18 @@
+package com.cedricziel.idea.typo3.util;
+
+import com.intellij.patterns.PlatformPatterns;
+import com.intellij.psi.PsiElement;
+import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
+
+public class ResourceUtil {
+    public static boolean isExtResourcePath(PsiElement element) {
+        // must be a string element
+        if (!PlatformPatterns.psiElement().withParent(PlatformPatterns.psiElement(StringLiteralExpression.class)).accepts(element)) {
+            return false;
+        }
+
+        String currentText = element.getParent().getText();
+
+        return element.getProject().getBasePath() != null && currentText.contains("EXT:");
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -297,6 +297,9 @@ It is a great inspiration for possible solutions and parts of the code.</p>
 
         <!-- inspections -->
         <inspectionToolProvider implementation="com.cedricziel.idea.typo3.codeInspection.TYPO3InspectionToolProvider"/>
+
+        <!-- got handlers -->
+        <gotoDeclarationHandler implementation="com.cedricziel.idea.typo3.codeInsight.navigation.PathResourceGotoDeclarationHandler"/>
     </extensions>
 
     <extensions defaultExtensionNs="com.jetbrains.php">


### PR DESCRIPTION
Users can now use "go to declaration" on "EXT:foo" resource paths and the IDE will propose matching elements.