### PR TITLE
Introduce Tablename Index and use it

### DIFF
--- a/src/main/java/com/cedricziel/idea/typo3/index/TablenameFileIndex.java
+++ b/src/main/java/com/cedricziel/idea/typo3/index/TablenameFileIndex.java
@@ -1,0 +1,82 @@
+package com.cedricziel.idea.typo3.index;
+
+import com.cedricziel.idea.typo3.index.externalizer.ObjectStreamDataExternalizer;
+import com.intellij.openapi.fileEditor.impl.LoadTextUtil;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.util.indexing.*;
+import com.intellij.util.io.DataExternalizer;
+import com.intellij.util.io.EnumeratorStringDescriptor;
+import com.intellij.util.io.KeyDescriptor;
+import gnu.trove.THashMap;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class TablenameFileIndex extends FileBasedIndexExtension <String, TextRange> {
+
+    public static ID<String, TextRange> KEY = ID.create("com.cedricziel.idea.typo3.index.tablename");
+
+    @NotNull
+    @Override
+    public ID<String, TextRange> getName() {
+        return KEY;
+    }
+
+    @NotNull
+    @Override
+    public DataIndexer<String, TextRange, FileContent> getIndexer() {
+        return inputData -> {
+            Map<String, TextRange> map = new THashMap<>();
+
+            CharSequence charSequence = LoadTextUtil.loadText(inputData.getFile());
+
+            final Matcher matcher = Pattern
+                    .compile("create\\s+table\\s+(if\\s+not\\s+exists\\s+)?([a-zA-Z_0-9]+)", Pattern.CASE_INSENSITIVE)
+                    .matcher(charSequence);
+
+            try {
+                while (matcher.find()) {
+                    if (matcher.groupCount() < 2) {
+                        return map;
+                    }
+
+                    map.put(matcher.group(2), new TextRange(matcher.start(), matcher.end()));
+                }
+            } catch (IllegalStateException e) {
+                // no matches
+            }
+
+            return map;
+        };
+    }
+
+    @NotNull
+    @Override
+    public KeyDescriptor<String> getKeyDescriptor() {
+        return EnumeratorStringDescriptor.INSTANCE;
+    }
+
+    @NotNull
+    @Override
+    public DataExternalizer<TextRange> getValueExternalizer() {
+        return new ObjectStreamDataExternalizer<>();
+    }
+
+    @Override
+    public int getVersion() {
+        return 0;
+    }
+
+    @NotNull
+    @Override
+    public FileBasedIndex.InputFilter getInputFilter() {
+        return file -> file.getName().equals("ext_tables.sql");
+    }
+
+    @Override
+    public boolean dependsOnFileContent() {
+        return true;
+    }
+}

--- a/src/main/java/com/cedricziel/idea/typo3/util/TableUtil.java
+++ b/src/main/java/com/cedricziel/idea/typo3/util/TableUtil.java
@@ -1,100 +1,69 @@
 package com.cedricziel.idea.typo3.util;
 
+import com.cedricziel.idea.typo3.index.TablenameFileIndex;
 import com.intellij.codeInsight.completion.CompletionResultSet;
 import com.intellij.codeInsight.lookup.LookupElement;
-import com.intellij.openapi.fileEditor.impl.LoadTextUtil;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiManager;
 import com.intellij.psi.search.FilenameIndex;
 import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.util.indexing.FileBasedIndex;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class TableUtil {
 
     public static final String EXT_TABLES_SQL_FILENAME = "ext_tables.sql";
 
     public static Set<String> getAvailableTableNames(@NotNull Project project) {
-        PsiFile[] extSqlFiles = getExtTablesSqlFilesInProject(project);
 
-        Set<String> tableNames = new HashSet<>();
-
-        for (PsiFile psiFile : extSqlFiles) {
-
-            if (psiFile != null) {
-
-                CharSequence charSequence = LoadTextUtil.loadText(psiFile.getVirtualFile());
-
-                final Matcher matcher = Pattern
-                        .compile("create\\s+table\\s+(if\\s+not\\s+exists\\s+)?([a-zA-Z_0-9]+)", Pattern.CASE_INSENSITIVE)
-                        .matcher(charSequence);
-
-                try {
-                    while (matcher.find()) {
-                        if (matcher.groupCount() < 2) {
-                            return tableNames;
-                        }
-
-                        tableNames.add(matcher.group(2));
-                    }
-                } catch (IllegalStateException e) {
-                    // no matches
-                }
-            }
-        }
-
-        return tableNames;
+        return new HashSet<>(FileBasedIndex.getInstance().getAllKeys(TablenameFileIndex.KEY, project));
     }
 
     public static PsiElement[] getTableDefinitionElements(@NotNull String tableName, @NotNull Project project) {
 
         PsiFile[] extTablesSqlFilesInProjectContainingTable = getExtTablesSqlFilesInProjectContainingTable(tableName, project);
+        Set<PsiElement> elements = new HashSet<>();
 
-        return Arrays
-                .stream(extTablesSqlFilesInProjectContainingTable)
-                .map(file -> {
-                    CharSequence charSequence = LoadTextUtil.loadText(file.getVirtualFile());
+        PsiManager psiManager = PsiManager.getInstance(project);
 
-                    final Matcher matcher = Pattern
-                            .compile("create\\s+table\\s+(if\\s+not\\s+exists\\s+)?([a-zA-Z_0-9]+)", Pattern.CASE_INSENSITIVE)
-                            .matcher(charSequence);
-                    try {
-                        while (matcher.find()) {
-                            if (matcher.groupCount() < 2) {
-                                continue;
-                            }
+        for (PsiFile virtualFile : extTablesSqlFilesInProjectContainingTable) {
+            FileBasedIndex.getInstance().processValues(TablenameFileIndex.KEY, tableName, virtualFile.getVirtualFile(), (file, value) -> {
 
-                            final String foundTable = matcher.group(2);
-                            if (!foundTable.equals(tableName)) {
-                                continue;
-                            }
-
-                            return file.findElementAt(matcher.end() - 2);
-                        }
-                    } catch (IllegalStateException e) {
-                        // do nothing
+                PsiFile file1 = psiManager.findFile(file);
+                if (file1 != null) {
+                    PsiElement elementAt = file1.findElementAt(value.getEndOffset() - 2);
+                    if (elementAt != null) {
+                        elements.add(elementAt);
                     }
+                }
 
-                    return null;
-                })
-                .filter(Objects::nonNull)
-                .toArray(PsiElement[]::new);
+                return true;
+            }, GlobalSearchScope.allScope(project));
+        }
+
+        return elements.toArray(new PsiElement[elements.size()]);
     }
 
     private static PsiFile[] getExtTablesSqlFilesInProjectContainingTable(@NotNull String tableName, @NotNull Project project) {
+        Set<String> set = new HashSet<>();
+        set.add(tableName);
 
-        return Arrays
-                .stream(getExtTablesSqlFilesInProject(project))
-                .filter(Objects::nonNull)
-                .filter(file -> LoadTextUtil.loadText(file.getVirtualFile()).toString().contains(tableName))
-                .toArray(PsiFile[]::new);
+        Set<PsiFile> files = new HashSet<>();
+        PsiManager psiManager = PsiManager.getInstance(project);
+
+        FileBasedIndex.getInstance().getFilesWithKey(TablenameFileIndex.KEY, set, virtualFile -> {
+
+            files.add(psiManager.findFile(virtualFile));
+
+            return true;
+        }, GlobalSearchScope.allScope(project));
+
+        return files.toArray(new PsiFile[files.size()]);
     }
 
     @NotNull

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -267,6 +267,7 @@ It is a great inspiration for possible solutions and parts of the code.</p>
         <!-- indexes -->
         <fileBasedIndex implementation="com.cedricziel.idea.typo3.index.CoreServiceMapStubIndex"/>
         <fileBasedIndex implementation="com.cedricziel.idea.typo3.index.ExtensionNameStubIndex"/>
+        <fileBasedIndex implementation="com.cedricziel.idea.typo3.index.TablenameFileIndex"/>
 
         <!-- completion -->
         <completion.contributor language="PHP"


### PR DESCRIPTION
The tablename index does one thing: Store text-ranges where a tables' definitions are.

It does so by saving a TextRange into the index and on access it pin-points directly to the element so we can find a PsiElement at the given position.