### PR TITLE
Use ScalarIndexExtension instead of DirectoryScanner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ cache:
   - $HOME/.gradle/caches/
   - $HOME/.gradle/wrapper/
 script:
+- "./gradlew check"
 - "./gradlew buildPlugin"
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ jdk:
 before_cache:
 - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
 - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+- rm -fr $HOME/.gradle/caches/*/fileHashes/fileHashes.bin
+- rm -fr $HOME/.gradle/caches/*/fileHashes/fileHashes.lock
 cache:
   directories:
   - $HOME/.gradle/caches/

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'java'
 
 intellij {
     version 'IU-2017.2.5'
-    plugins = ['com.jetbrains.php:172.4155.41']
+    plugins = ['com.jetbrains.php:172.4155.41', 'CSS', 'java-i18n', 'properties']
     pluginName 'TYPO3 CMS Plugin'
 
     publishPlugin {

--- a/src/main/java/com/cedricziel/idea/typo3/annotation/PathResourceAnnotator.java
+++ b/src/main/java/com/cedricziel/idea/typo3/annotation/PathResourceAnnotator.java
@@ -1,18 +1,11 @@
 package com.cedricziel.idea.typo3.annotation;
 
+import com.cedricziel.idea.typo3.index.ResourcePathIndex;
 import com.intellij.lang.annotation.AnnotationHolder;
 import com.intellij.lang.annotation.Annotator;
-import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
-import com.intellij.psi.PsiFile;
-import com.intellij.psi.search.FilenameIndex;
-import com.intellij.psi.search.GlobalSearchScope;
 import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
-import org.codehaus.plexus.util.DirectoryScanner;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * Matches {@link StringLiteralExpression} elements and annotates them if a resource does not exist.
@@ -38,40 +31,13 @@ public class PathResourceAnnotator implements Annotator {
             return;
         }
 
-        String[] split = resourceName.split("/");
-        String fileName = split[split.length - 1];
-        DirectoryScanner scanner = new DirectoryScanner();
-
-        scanner.setBasedir(element.getProject().getBasePath());
-        scanner.addDefaultExcludes();
-        scanner.setIncludes(new String[]{"**/" + resourceName + "/"});
-        scanner.scan();
-
-        String[] paths = scanner.getIncludedFiles();
-        if (paths.length != 0) {
-            // the resource is a directory
+        if (ResourcePathIndex.projectContainsResourceFile(element.getProject(), content)) {
+            // exact match found
             return;
         }
 
-        List<PsiFile> filesByName = Arrays.asList(FilenameIndex.getFilesByName(element.getProject(), fileName, GlobalSearchScope.allScope(element.getProject())));
-        if (filesByName.size() == 0) {
-            createErrorMessage(element, holder, resourceName);
-
+        if (ResourcePathIndex.projectContainsResourceDirectory(element.getProject(), content)) {
             return;
-        }
-
-        for (PsiFile file : filesByName) {
-            VirtualFile virtualFile = file.getVirtualFile();
-
-
-            if (virtualFile.getPath().contains("typo3conf/ext/" + resourceName) || virtualFile.getPath().contains("sysext/" + resourceName)) {
-                // all good
-                return;
-            }
-
-            if (virtualFile.isDirectory() && virtualFile.getPath().endsWith(resourceName)) {
-                return;
-            }
         }
 
         createErrorMessage(element, holder, resourceName);

--- a/src/main/java/com/cedricziel/idea/typo3/codeInsight/PathResourceCompletionContributor.java
+++ b/src/main/java/com/cedricziel/idea/typo3/codeInsight/PathResourceCompletionContributor.java
@@ -1,18 +1,14 @@
 package com.cedricziel.idea.typo3.codeInsight;
 
+import com.cedricziel.idea.typo3.index.ResourcePathIndex;
 import com.intellij.codeInsight.completion.*;
-import com.intellij.codeInsight.lookup.LookupElement;
-import com.intellij.codeInsight.lookup.LookupElementPresentation;
-import com.intellij.icons.AllIcons;
+import com.intellij.codeInsight.lookup.LookupElementBuilder;
 import com.intellij.openapi.project.Project;
 import com.intellij.patterns.PlatformPatterns;
 import com.intellij.psi.PsiElement;
 import com.intellij.util.ProcessingContext;
 import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
-import org.codehaus.plexus.util.DirectoryScanner;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.Arrays;
 
 public class PathResourceCompletionContributor extends CompletionContributor {
     public PathResourceCompletionContributor() {
@@ -31,79 +27,8 @@ public class PathResourceCompletionContributor extends CompletionContributor {
                             return;
                         }
 
-                        String[] includes;
-                        if (currentText.contains("/")) {
-                            String current = currentText
-                                    .split("/", 1)[0]
-                                    .replace("EXT:", "")
-                                    .replace("IntellijIdeaRulezzz", "")
-                                    .replace("'", "")
-                                    .trim();
-
-                            includes = new String[]{
-                                    "**/sysext/" + current + "**",
-                                    "**/typo3conf/ext/" + current + "**",
-                            };
-                        } else {
-                            includes = new String[]{
-                                    "**/sysext/*/",
-                                    "**/typo3conf/ext/*/",
-                            };
-                        }
-
-                        DirectoryScanner scanner = new DirectoryScanner();
-
-                        scanner.setBasedir(project.getBasePath());
-                        scanner.addDefaultExcludes();
-                        scanner.setIncludes(includes);
-                        scanner.scan();
-
-                        Arrays.stream(scanner.getIncludedFiles()).forEach(f -> {
-                            result.addElement(new LookupElement() {
-                                @NotNull
-                                @Override
-                                public String getLookupString() {
-                                    String[] splitted = f.split("sysext/");
-                                    if (splitted.length > 1) {
-                                        return "EXT:" + splitted[1];
-                                    }
-
-                                    splitted = f.split("typo3conf/ext/");
-                                    if (splitted.length > 1) {
-                                        return "EXT:" + splitted[1];
-                                    }
-
-                                    return "EXT:" + f;
-                                }
-                            });
-                        });
-
-                        Arrays.stream(scanner.getIncludedDirectories()).forEach(f -> {
-                            result.addElement(new LookupElement() {
-
-                                @Override
-                                public void renderElement(LookupElementPresentation presentation) {
-                                    presentation.setIcon(AllIcons.Modules.SourceFolder);
-
-                                    super.renderElement(presentation);
-                                }
-
-                                @NotNull
-                                @Override
-                                public String getLookupString() {
-                                    String[] splitted = f.split("sysext/");
-                                    if (splitted.length > 1) {
-                                        return "EXT:" + splitted[1];
-                                    }
-
-                                    splitted = f.split("typo3conf/ext/");
-                                    if (splitted.length > 1) {
-                                        return "EXT:" + splitted[1];
-                                    }
-
-                                    return "EXT:" + f;
-                                }
-                            });
+                        ResourcePathIndex.getAvailableExtensionResourceFiles(project).forEach(identifier -> {
+                            result.addElement(LookupElementBuilder.create(identifier));
                         });
                     }
                 }

--- a/src/main/java/com/cedricziel/idea/typo3/codeInsight/navigation/PathResourceGotoDeclarationHandler.java
+++ b/src/main/java/com/cedricziel/idea/typo3/codeInsight/navigation/PathResourceGotoDeclarationHandler.java
@@ -1,17 +1,12 @@
 package com.cedricziel.idea.typo3.codeInsight.navigation;
 
+import com.cedricziel.idea.typo3.index.ResourcePathIndex;
 import com.intellij.codeInsight.navigation.actions.GotoDeclarationHandler;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.psi.PsiElement;
-import com.intellij.psi.PsiFile;
-import com.intellij.psi.search.FilenameIndex;
-import com.intellij.psi.search.GlobalSearchScope;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.Arrays;
-import java.util.List;
 
 import static com.cedricziel.idea.typo3.util.ResourceUtil.isExtResourcePath;
 
@@ -24,26 +19,8 @@ public class PathResourceGotoDeclarationHandler implements GotoDeclarationHandle
         }
 
         if (sourceElement != null) {
-            String text = sourceElement.getText();
-            String[] strings = text.split("/");
-            if (strings.length == 0) {
-                return emptyPsiElementArray();
-            }
-
-            String fileName = strings[strings.length - 1];
-            String relativePath = text.replaceFirst("EXT:", "");
-
-            List<PsiFile> psiFiles = Arrays.asList(
-                    FilenameIndex.getFilesByName(
-                            sourceElement.getProject(),
-                            fileName,
-                            GlobalSearchScope.allScope(sourceElement.getProject())
-                    ));
-
-            return psiFiles
-                    .stream()
-                    .filter(x -> x.getVirtualFile().getPath().contains(relativePath))
-                    .toArray(PsiElement[]::new);
+            String identifier = sourceElement.getText();
+            return ResourcePathIndex.findElementsForKey(sourceElement.getProject(), identifier);
         }
 
         return emptyPsiElementArray();

--- a/src/main/java/com/cedricziel/idea/typo3/index/ResourcePathIndex.java
+++ b/src/main/java/com/cedricziel/idea/typo3/index/ResourcePathIndex.java
@@ -1,0 +1,81 @@
+package com.cedricziel.idea.typo3.index;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.util.indexing.*;
+import com.intellij.util.io.EnumeratorStringDescriptor;
+import com.intellij.util.io.KeyDescriptor;
+import gnu.trove.THashMap;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.Map;
+
+public class ResourcePathIndex extends ScalarIndexExtension<String> {
+
+    public static final ID<String, Void> KEY = ID.create("com.cedricziel.idea.typo3.index.resource_path");
+
+    @NotNull
+    @Override
+    public ID<String, Void> getName() {
+        return KEY;
+    }
+
+    @NotNull
+    @Override
+    public DataIndexer<String, Void, FileContent> getIndexer() {
+        return inputData -> {
+            Map<String, Void> map = new THashMap<>();
+
+            map.put(compileId(inputData), null);
+
+            return map;
+        };
+    }
+
+    private String compileId(FileContent inputData) {
+        String path = inputData.getFile().getPath();
+        String filePosition = "";
+        if (path.contains("typo3conf/ext/")) {
+            filePosition = path.split("typo3conf/ext/")[1];
+        }
+        if (path.contains("sysext/")) {
+            filePosition = path.split("sysext/")[1];
+        }
+
+        return "EXT:" + filePosition;
+    }
+
+    @NotNull
+    @Override
+    public KeyDescriptor<String> getKeyDescriptor() {
+        return EnumeratorStringDescriptor.INSTANCE;
+    }
+
+    @Override
+    public int getVersion() {
+        return 0;
+    }
+
+    @NotNull
+    @Override
+    public FileBasedIndex.InputFilter getInputFilter() {
+        return file -> file.isInLocalFileSystem() && (file.getPath().contains("sysext") ||file.getPath().contains("typo3conf/ext"));
+    }
+
+    @Override
+    public boolean dependsOnFileContent() {
+        return false;
+    }
+
+    public static Collection<String> getAvailableExtensionResourceFiles(@NotNull Project project) {
+        return FileBasedIndex.getInstance().getAllKeys(ResourcePathIndex.KEY, project);
+    }
+
+    public static boolean projectContainsResourceFile(@NotNull Project project, @NotNull String resourceId) {
+        return FileBasedIndex.getInstance().getAllKeys(ResourcePathIndex.KEY, project).contains(resourceId);
+    }
+
+    public static boolean projectContainsResourceDirectory(@NotNull Project project, @NotNull String resourceId) {
+        return false;
+    }
+}

--- a/src/main/java/com/cedricziel/idea/typo3/index/ResourcePathIndex.java
+++ b/src/main/java/com/cedricziel/idea/typo3/index/ResourcePathIndex.java
@@ -1,18 +1,49 @@
 package com.cedricziel.idea.typo3.index;
 
 import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiManager;
+import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.util.indexing.*;
 import com.intellij.util.io.EnumeratorStringDescriptor;
 import com.intellij.util.io.KeyDescriptor;
 import gnu.trove.THashMap;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Collection;
-import java.util.Map;
+import java.util.*;
 
 public class ResourcePathIndex extends ScalarIndexExtension<String> {
 
     public static final ID<String, Void> KEY = ID.create("com.cedricziel.idea.typo3.index.resource_path");
+
+    public static Collection<String> getAvailableExtensionResourceFiles(@NotNull Project project) {
+        return FileBasedIndex.getInstance().getAllKeys(ResourcePathIndex.KEY, project);
+    }
+
+    public static boolean projectContainsResourceFile(@NotNull Project project, @NotNull String resourceId) {
+        return FileBasedIndex.getInstance().getAllKeys(ResourcePathIndex.KEY, project).contains(resourceId);
+    }
+
+    public static boolean projectContainsResourceDirectory(@NotNull Project project, @NotNull String resourceId) {
+        return false;
+    }
+
+    public static PsiElement[] findElementsForKey(@NotNull Project project, @NotNull String identifier) {
+        Set<String> keys = new HashSet<>();
+        keys.add(identifier);
+        Set<PsiElement> elements = new HashSet<>();
+
+        FileBasedIndex.getInstance().getFilesWithKey(ResourcePathIndex.KEY, keys, virtualFile -> {
+            elements.add(PsiManager.getInstance(project).findFile(virtualFile));
+
+            return true;
+        }, GlobalSearchScope.allScope(project));
+
+        return elements
+                .stream()
+                .filter(Objects::nonNull)
+                .toArray(PsiElement[]::new);
+    }
 
     @NotNull
     @Override
@@ -59,23 +90,11 @@ public class ResourcePathIndex extends ScalarIndexExtension<String> {
     @NotNull
     @Override
     public FileBasedIndex.InputFilter getInputFilter() {
-        return file -> file.isInLocalFileSystem() && (file.getPath().contains("sysext") ||file.getPath().contains("typo3conf/ext"));
+        return file -> file.isInLocalFileSystem() && (file.getPath().contains("sysext") || file.getPath().contains("typo3conf/ext"));
     }
 
     @Override
     public boolean dependsOnFileContent() {
-        return false;
-    }
-
-    public static Collection<String> getAvailableExtensionResourceFiles(@NotNull Project project) {
-        return FileBasedIndex.getInstance().getAllKeys(ResourcePathIndex.KEY, project);
-    }
-
-    public static boolean projectContainsResourceFile(@NotNull Project project, @NotNull String resourceId) {
-        return FileBasedIndex.getInstance().getAllKeys(ResourcePathIndex.KEY, project).contains(resourceId);
-    }
-
-    public static boolean projectContainsResourceDirectory(@NotNull Project project, @NotNull String resourceId) {
         return false;
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -268,6 +268,7 @@ It is a great inspiration for possible solutions and parts of the code.</p>
         <fileBasedIndex implementation="com.cedricziel.idea.typo3.index.CoreServiceMapStubIndex"/>
         <fileBasedIndex implementation="com.cedricziel.idea.typo3.index.ExtensionNameStubIndex"/>
         <fileBasedIndex implementation="com.cedricziel.idea.typo3.index.IconIndex"/>
+        <fileBasedIndex implementation="com.cedricziel.idea.typo3.index.ResourcePathIndex"/>
         <fileBasedIndex implementation="com.cedricziel.idea.typo3.index.TablenameFileIndex"/>
 
         <!-- completion -->

--- a/src/test/java/com/cedricziel/idea/typo3/codeInsight/PathResourceCompletionContributorTest.java
+++ b/src/test/java/com/cedricziel/idea/typo3/codeInsight/PathResourceCompletionContributorTest.java
@@ -1,0 +1,14 @@
+package com.cedricziel.idea.typo3.codeInsight;
+
+import com.cedricziel.idea.typo3.index.ResourcePathIndex;
+import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase;
+
+public class PathResourceCompletionContributorTest extends LightCodeInsightFixtureTestCase {
+    public void testResourcesAreIndexed() {
+        myFixture.addFileToProject("typo3conf/ext/foo/bar.php", "");
+        myFixture.addFileToProject("typo3/sysext/baz/bar.png", "");
+
+        assertTrue(ResourcePathIndex.projectContainsResourceFile(myFixture.getProject(), "EXT:foo/bar.php"));
+        assertTrue(ResourcePathIndex.projectContainsResourceFile(myFixture.getProject(), "EXT:baz/bar.png"));
+    }
+}

--- a/src/test/java/com/cedricziel/idea/typo3/index/ResourcePathIndexTest.java
+++ b/src/test/java/com/cedricziel/idea/typo3/index/ResourcePathIndexTest.java
@@ -1,0 +1,25 @@
+package com.cedricziel.idea.typo3.index;
+
+import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase;
+import com.jetbrains.php.lang.PhpFileType;
+
+import java.util.List;
+
+public class ResourcePathIndexTest extends LightCodeInsightFixtureTestCase {
+    public void testResourcesAreIndexed() {
+        myFixture.addFileToProject("typo3conf/ext/foo/bar.php", "");
+        myFixture.addFileToProject("typo3/sysext/baz/bar.png", "");
+        myFixture.configureByText(PhpFileType.INSTANCE, "<?php \n" +
+                "echo 'EXT:<caret>';");
+        myFixture.completeBasic();
+
+        List<String> lookupElementStrings = myFixture.getLookupElementStrings();
+
+        if (lookupElementStrings == null) {
+            fail("Could not complete");
+        }
+
+        assertContainsElements(lookupElementStrings, "EXT:foo/bar.php");
+        assertContainsElements(lookupElementStrings, "EXT:baz/bar.png");
+    }
+}

--- a/src/test/java/com/cedricziel/idea/typo3/util/ResourceUtilTest.java
+++ b/src/test/java/com/cedricziel/idea/typo3/util/ResourceUtilTest.java
@@ -1,0 +1,4 @@
+package com.cedricziel.idea.typo3.util;
+
+public class ResourceUtilTest {
+}

--- a/src/test/java/com/cedricziel/idea/typo3/util/ResourceUtilTest.java
+++ b/src/test/java/com/cedricziel/idea/typo3/util/ResourceUtilTest.java
@@ -1,4 +1,0 @@
-package com.cedricziel.idea.typo3.util;
-
-public class ResourceUtilTest {
-}


### PR DESCRIPTION
DirectoryScanner is only available in IntelliJ and breaks resource discovery in PHPStorm.

This PR moves away from it and indexes all available resource files and then instead of dynamically collecting available files queris the index for its keys.

Fixes: #82