### PR TITLE
Resolve extension-keys from unconventional paths

### DIFF
--- a/src/main/java/com/cedricziel/idea/typo3/util/ComposerUtil.java
+++ b/src/main/java/com/cedricziel/idea/typo3/util/ComposerUtil.java
@@ -1,0 +1,120 @@
+package com.cedricziel.idea.typo3.util;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.jetbrains.php.composer.ComposerConfigUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+
+public class ComposerUtil {
+    @Nullable
+    public static String extensionKeyFromPackageName(JsonElement jsonElement) {
+        JsonElement nameElement = jsonElement.getAsJsonObject().get("name");
+        if (nameElement != null) {
+            String name = nameElement.getAsString();
+            if (name != null) {
+                if (name.contains("/")) {
+                    return name.split("/")[1].replaceAll("-", "_");
+                }
+            }
+        }
+
+        return null;
+    }
+
+    public static String extensionKeyFromInstallerName(JsonElement jsonElement) {
+
+        JsonObject asJsonObject = jsonElement.getAsJsonObject();
+        if (!asJsonObject.has("extra")) {
+            return null;
+        }
+
+        JsonObject extra = asJsonObject.get("extra").getAsJsonObject();
+        if (!extra.has("installerName")) {
+            return null;
+        }
+
+        return extra.getAsJsonObject().getAsJsonPrimitive("installerName").getAsString();
+    }
+
+    public static String extensionKeyFromExtraExtensionKey(JsonElement jsonElement) {
+
+        JsonObject asJsonObject = jsonElement.getAsJsonObject();
+        if (!asJsonObject.has("extra")) {
+            return null;
+        }
+
+        JsonObject extra = asJsonObject.get("extra").getAsJsonObject();
+        if (!extra.has("typo3/cms")) {
+            return null;
+        }
+
+        JsonObject typo3Extras = extra.getAsJsonObject("typo3/cms");
+        if (!typo3Extras.has("extension-key")) {
+            return null;
+        }
+
+        return typo3Extras.getAsJsonPrimitive("extension-key").getAsString();
+    }
+
+    public static String packageType(JsonElement jsonElement) {
+
+        JsonObject asJsonObject = jsonElement.getAsJsonObject();
+        if (!asJsonObject.has("type")) {
+            return null;
+        }
+
+        return asJsonObject.get("type").getAsJsonPrimitive().getAsString();
+    }
+
+    public static boolean isTYPO3ExtensionManifest(JsonElement jsonElement) {
+
+        String packageType = packageType(jsonElement);
+        if (packageType == null) {
+            return false;
+        }
+
+        return packageType.equals("typo3-cms-extension");
+    }
+
+    @Nullable
+    public static String findExtensionKey(@NotNull VirtualFile composerJsonFile) {
+        try {
+            JsonElement jsonElement = ComposerConfigUtils.parseJson(composerJsonFile);
+
+            if (!isTYPO3ExtensionManifest(jsonElement)) {
+                return null;
+            }
+
+            // 1.1 find extra.typo3/cms.extension-key
+            String extensionKeyFromExtrasTYPO3 = extensionKeyFromExtraExtensionKey(jsonElement);
+            if (extensionKeyFromExtrasTYPO3 != null) {
+                return extensionKeyFromExtrasTYPO3;
+            }
+
+            // 1.2 find extra.installerName
+            String extensionKeyFromInstallerName = extensionKeyFromInstallerName(jsonElement);
+            if (extensionKeyFromInstallerName != null) {
+                return extensionKeyFromInstallerName;
+            }
+
+            // 1.3 last resort: package-name
+            String extensionKeyFromPackageName = extensionKeyFromPackageName(jsonElement);
+            if (extensionKeyFromPackageName != null) {
+                return extensionKeyFromPackageName;
+            }
+
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        } catch (JsonSyntaxException | IllegalStateException e) {
+            // nothing, yo
+        }
+
+        return null;
+    }
+}

--- a/src/test/java/com/cedricziel/idea/typo3/index/ResourcePathIndexTest.java
+++ b/src/test/java/com/cedricziel/idea/typo3/index/ResourcePathIndexTest.java
@@ -22,4 +22,60 @@ public class ResourcePathIndexTest extends LightCodeInsightFixtureTestCase {
         assertContainsElements(lookupElementStrings, "EXT:foo/bar.php");
         assertContainsElements(lookupElementStrings, "EXT:baz/bar.png");
     }
+
+    public void testInstallerNameUnconventionalResourcePathsAreDetected() {
+
+        // extension key "cascaded" resolved through extra.typo3/cms.extension-key
+        myFixture.addFileToProject("cc/ext_emconf.php", "");
+        myFixture.addFileToProject("cc/composer.json", "{\n" +
+                "\t\"name\": \"package/foo\",\n" +
+                "\t\"bar\": \"baz\",\n" +
+                "\t\"type\": \"typo3-cms-extension\",\n" +
+                "\t\"extra\": {\n" +
+                "\t\t\"installerName\": \"foo_bar_baz\",\n" +
+                "\t\t\"typo3/cms\": {\n" +
+                "\t\t\t\"extension-key\": \"cascaded\"\n" +
+                "\t\t}\n" +
+                "\t}\n" +
+                "}\n");
+
+        // extension key "bar" resolved through package name
+        myFixture.addFileToProject("bar_bz/ext_emconf.php", "");
+        myFixture.addFileToProject("bar_bz/composer.json", "{\n" +
+                "\t\"name\": \"package/bar\",\n" +
+                "\t\"bar\": \"baz\",\n" +
+                "\t\"type\": \"typo3-cms-extension\",\n" +
+                "\t\"extra\": {\n" +
+                "\t}\n" +
+                "}\n");
+
+        // extension key "foo_bar_baz" resolved through the extras.installerName property
+        myFixture.addFileToProject("foo/ext_emconf.php", "");
+        myFixture.addFileToProject("foo/composer.json", "{\n" +
+                "\t\"name\": \"package/foo\",\n" +
+                "\t\"bar\": \"baz\",\n" +
+                "\t\"type\": \"typo3-cms-extension\",\n" +
+                "\t\"extra\": {\n" +
+                "\t\t\"installerName\": \"foo_bar_baz\"\n" +
+                "\t}\n" +
+                "}\n");
+
+        // extension key "bingo" resolved through the folder
+        myFixture.addFileToProject("bingo/ext_emconf.php", "");
+
+        myFixture.configureByText(PhpFileType.INSTANCE, "<?php \n" +
+                "echo 'EXT:<caret>';");
+        myFixture.completeBasic();
+
+        List<String> lookupElementStrings = myFixture.getLookupElementStrings();
+
+        if (lookupElementStrings == null) {
+            fail("Could not complete");
+        }
+
+        assertContainsElements(lookupElementStrings, "EXT:cascaded/ext_emconf.php");
+        assertContainsElements(lookupElementStrings, "EXT:bingo/ext_emconf.php");
+        assertContainsElements(lookupElementStrings, "EXT:foo_bar_baz/ext_emconf.php");
+        assertContainsElements(lookupElementStrings, "EXT:bar/ext_emconf.php");
+    }
 }


### PR DESCRIPTION
This should allow unconventional paths in a project. The plugin can now detect extension root paths by finding ext_emconf.php files and analyzing sibling composer.json files.

A proper TYPO3 extensions' `composer.json` looks like this:

```json
{
	"name": "package/foo", // priority 3
	"bar": "baz",
	"type": "typo3-cms-extension", // *mandatory*
	"extra": {
		"installerName": "foo_bar_baz", // Priority 2
		"typo3/cms": {
			"extension-key": "my_key" // Priority 1
		}
	}
}
```

Please note that the `type` key is needed to properly detect the package.

[TYPO3 CMS Plugin-v0.2.20-1-g78f78a6.zip](https://github.com/cedricziel/idea-php-typo3-plugin/files/1500307/TYPO3.CMS.Plugin-v0.2.20-1-g78f78a6.zip)

Resolves: #87