### PR TITLE
Allow resolving resource paths with trailing slashes

### DIFF
--- a/src/main/java/com/cedricziel/idea/typo3/codeInsight/navigation/PathResourceGotoDeclarationHandler.java
+++ b/src/main/java/com/cedricziel/idea/typo3/codeInsight/navigation/PathResourceGotoDeclarationHandler.java
@@ -20,6 +20,11 @@ public class PathResourceGotoDeclarationHandler implements GotoDeclarationHandle
 
         if (sourceElement != null) {
             String identifier = sourceElement.getText();
+
+            if (ResourcePathIndex.projectContainsResourceDirectory(sourceElement.getProject(), identifier)) {
+                return emptyPsiElementArray();
+            }
+
             return ResourcePathIndex.findElementsForKey(sourceElement.getProject(), identifier);
         }
 

--- a/src/main/java/com/cedricziel/idea/typo3/index/ResourcePathIndex.java
+++ b/src/main/java/com/cedricziel/idea/typo3/index/ResourcePathIndex.java
@@ -9,6 +9,7 @@ import com.intellij.util.indexing.*;
 import com.intellij.util.io.EnumeratorStringDescriptor;
 import com.intellij.util.io.KeyDescriptor;
 import gnu.trove.THashMap;
+import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -29,7 +30,23 @@ public class ResourcePathIndex extends ScalarIndexExtension<String> {
     }
 
     public static boolean projectContainsResourceDirectory(@NotNull Project project, @NotNull String resourceId) {
-        return false;
+        Set<String> keys = new HashSet<>();
+        keys.add(StringUtils.strip(resourceId, "/"));
+
+        Set<VirtualFile> matches = new HashSet<>();
+
+        FileBasedIndex.getInstance().getFilesWithKey(ResourcePathIndex.KEY, keys, file -> {
+            if (file.isDirectory()) {
+
+                matches.add(file);
+
+                return false;
+            }
+
+            return true;
+        }, GlobalSearchScope.allScope(project));
+
+        return matches.size() > 0;
     }
 
     public static PsiElement[] findElementsForKey(@NotNull Project project, @NotNull String identifier) {


### PR DESCRIPTION
This checks for existence of a folder resource.

[TYPO3 CMS Plugin-v0.2.21-1-g3f2006f.zip](https://github.com/cedricziel/idea-php-typo3-plugin/files/1501834/TYPO3.CMS.Plugin-v0.2.21-1-g3f2006f.zip)

Resolves: #89