### PR TITLE
Autocomplete and cross-reference resources in YAML files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'java'
 intellij {
     version ideaVersion
     pluginName 'TYPO3 CMS Plugin'
-    plugins = ["com.jetbrains.php:${phpPluginVersion}", 'CSS', 'java-i18n', 'properties']
+    plugins = ["com.jetbrains.php:${phpPluginVersion}", 'CSS', 'java-i18n', 'properties', 'yaml']
     downloadSources !Boolean.valueOf(System.getenv('CI'))
 
     publishPlugin {

--- a/src/main/java/com/cedricziel/idea/typo3/resources/ResourceReference.java
+++ b/src/main/java/com/cedricziel/idea/typo3/resources/ResourceReference.java
@@ -7,6 +7,7 @@ import com.intellij.psi.PsiPolyVariantReferenceBase;
 import com.intellij.psi.ResolveResult;
 import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.yaml.psi.YAMLQuotedText;
 
 public class ResourceReference extends PsiPolyVariantReferenceBase<PsiElement> {
     private final String resourceName;
@@ -15,6 +16,12 @@ public class ResourceReference extends PsiPolyVariantReferenceBase<PsiElement> {
         super(psiElement);
 
         this.resourceName = psiElement.getContents();
+    }
+
+    public ResourceReference(YAMLQuotedText psiElement) {
+        super(psiElement);
+
+        this.resourceName = psiElement.getTextValue();
     }
 
     /**

--- a/src/main/java/com/cedricziel/idea/typo3/resources/ResourceReferenceContributor.java
+++ b/src/main/java/com/cedricziel/idea/typo3/resources/ResourceReferenceContributor.java
@@ -5,11 +5,12 @@ import com.intellij.psi.*;
 import com.intellij.util.ProcessingContext;
 import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.yaml.psi.YAMLQuotedText;
 
 public class ResourceReferenceContributor extends PsiReferenceContributor {
     @Override
     public void registerReferenceProviders(@NotNull PsiReferenceRegistrar registrar) {
-        // "EXT:" strings
+        // PHP: "EXT:" strings
         registrar.registerReferenceProvider(
                 PlatformPatterns.psiElement(StringLiteralExpression.class),
                 new PsiReferenceProvider() {
@@ -19,6 +20,24 @@ public class ResourceReferenceContributor extends PsiReferenceContributor {
 
                         StringLiteralExpression stringLiteralExpression = (StringLiteralExpression)element;
                         if (!stringLiteralExpression.getContents().startsWith("EXT:") && !stringLiteralExpression.getContents().startsWith("LLL:EXT:")) {
+                            return new PsiReference[0];
+                        }
+
+                        return new PsiReference[]{new ResourceReference(stringLiteralExpression)};
+                    }
+                }
+        );
+
+        // YAML: "EXT:" strings
+        registrar.registerReferenceProvider(
+                PlatformPatterns.psiElement(YAMLQuotedText.class),
+                new PsiReferenceProvider() {
+                    @NotNull
+                    @Override
+                    public PsiReference[] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
+
+                        YAMLQuotedText stringLiteralExpression = (YAMLQuotedText)element;
+                        if (!stringLiteralExpression.getTextValue().startsWith("EXT:") && !stringLiteralExpression.getTextValue().startsWith("LLL:EXT:")) {
                             return new PsiReference[0];
                         }
 

--- a/src/main/java/com/cedricziel/idea/typo3/resources/ResourceReferenceContributor.java
+++ b/src/main/java/com/cedricziel/idea/typo3/resources/ResourceReferenceContributor.java
@@ -36,12 +36,12 @@ public class ResourceReferenceContributor extends PsiReferenceContributor {
                     @Override
                     public PsiReference[] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
 
-                        YAMLQuotedText stringLiteralExpression = (YAMLQuotedText)element;
-                        if (!stringLiteralExpression.getTextValue().startsWith("EXT:") && !stringLiteralExpression.getTextValue().startsWith("LLL:EXT:")) {
+                        YAMLQuotedText yamlQuotedText = (YAMLQuotedText)element;
+                        if (!yamlQuotedText.getTextValue().startsWith("EXT:") && !yamlQuotedText.getTextValue().startsWith("LLL:EXT:")) {
                             return new PsiReference[0];
                         }
 
-                        return new PsiReference[]{new ResourceReference(stringLiteralExpression)};
+                        return new PsiReference[]{new ResourceReference(yamlQuotedText)};
                     }
                 }
         );

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -133,6 +133,7 @@ It is a great inspiration for possible solutions and parts of the code.</p>
     <depends>com.intellij.modules.platform</depends>
     <depends>com.jetbrains.php</depends>
     <depends>com.intellij.modules.xml</depends>
+    <depends>org.jetbrains.plugins.yaml</depends>
 
     <extensions defaultExtensionNs="com.jetbrains.php">
         <typeProvider3 implementation="com.cedricziel.idea.typo3.provider.GeneralUtilityTypeProvider"/>

--- a/src/test/java/com/cedricziel/idea/typo3/resources/php/ResourceReferenceContributorTest.java
+++ b/src/test/java/com/cedricziel/idea/typo3/resources/php/ResourceReferenceContributorTest.java
@@ -1,5 +1,7 @@
-package com.cedricziel.idea.typo3.resources;
+package com.cedricziel.idea.typo3.resources.php;
 
+import com.cedricziel.idea.typo3.resources.ResourceLookupElement;
+import com.cedricziel.idea.typo3.resources.ResourceReference;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiReference;

--- a/src/test/java/com/cedricziel/idea/typo3/resources/yaml/ResourceReferenceContributorTest.java
+++ b/src/test/java/com/cedricziel/idea/typo3/resources/yaml/ResourceReferenceContributorTest.java
@@ -1,0 +1,90 @@
+package com.cedricziel.idea.typo3.resources.yaml;
+
+import com.cedricziel.idea.typo3.resources.ResourceLookupElement;
+import com.cedricziel.idea.typo3.resources.ResourceReference;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiReference;
+import com.intellij.psi.ResolveResult;
+import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase;
+import org.jetbrains.yaml.YAMLFileType;
+
+public class ResourceReferenceContributorTest extends LightCodeInsightFixtureTestCase {
+    public void testResourceReferencesAreCreated() {
+        myFixture.addFileToProject("foo/ext_emconf.php", "");
+        myFixture.addFileToProject("foo/Configuration/RTE/Processing.yaml", "");
+
+        myFixture.configureByText(YAMLFileType.YML, "imports:\n" +
+                "  - { resource: \"EXT:foo/Configuration/RTE/<caret>Processing.yaml\" }';");
+
+        PsiElement elementAtCaret = myFixture.getFile().findElementAt(myFixture.getCaretOffset()).getParent();
+
+        PsiReference[] references = elementAtCaret.getReferences();
+        for (PsiReference ref : references) {
+            if (ref instanceof ResourceReference) {
+                return;
+            }
+        }
+
+        fail("No resource reference.");
+    }
+
+    public void testResourceReferenceHasVariants() {
+        myFixture.addFileToProject("foo/ext_emconf.php", "");
+        myFixture.addFileToProject("foo/bar.txt", "");
+        myFixture.addFileToProject("foo/Configuration/RTE/Processing.yaml", "");
+
+        myFixture.configureByText(YAMLFileType.YML, "imports:\n" +
+                "  - { resource: \"EXT:foo/Configuration/RTE/<caret>Processing.yaml\" }';");
+
+        PsiElement elementAtCaret = myFixture.getFile().findElementAt(myFixture.getCaretOffset()).getParent();
+
+        ResourceReference target = null;
+        PsiReference[] references = elementAtCaret.getReferences();
+        for (PsiReference ref : references) {
+            if (ref instanceof ResourceReference) {
+                target = (ResourceReference) ref;
+            }
+        }
+
+        if (target != null) {
+            for (Object o : target.getVariants()) {
+                if (o instanceof ResourceLookupElement && ((ResourceLookupElement) o).getLookupString().contains("EXT:foo/bar.txt")) {
+                    return;
+                }
+            }
+        }
+
+        fail("No resource reference.");
+    }
+
+    public void testResourceReferenceResolves() {
+        PsiFile psiFile = myFixture.addFileToProject("foo/ext_emconf.php", "");
+        myFixture.addFileToProject("foo/bar.txt", "");
+
+        myFixture.addFileToProject("foo/Configuration/RTE/Processing.yaml", "");
+
+        myFixture.configureByText(YAMLFileType.YML, "imports:\n" +
+                "  - { resource: \"EXT:foo/Configuration/RTE/<caret>Processing.yaml\" }';");
+
+        PsiElement elementAtCaret = myFixture.getFile().findElementAt(myFixture.getCaretOffset()).getParent();
+
+        ResourceReference target = null;
+        PsiReference[] references = elementAtCaret.getReferences();
+        for (PsiReference ref : references) {
+            if (ref instanceof ResourceReference) {
+                target = (ResourceReference) ref;
+            }
+        }
+
+        if (target != null) {
+            for (ResolveResult o : target.multiResolve(true)) {
+                if (o.getElement().isEquivalentTo(psiFile)) {
+                    return;
+                }
+            }
+        }
+
+        fail("No resource reference.");
+    }
+}

--- a/src/test/java/com/cedricziel/idea/typo3/resources/yaml/ResourceReferenceContributorTest.java
+++ b/src/test/java/com/cedricziel/idea/typo3/resources/yaml/ResourceReferenceContributorTest.java
@@ -59,13 +59,13 @@ public class ResourceReferenceContributorTest extends LightCodeInsightFixtureTes
     }
 
     public void testResourceReferenceResolves() {
-        PsiFile psiFile = myFixture.addFileToProject("foo/ext_emconf.php", "");
+        myFixture.addFileToProject("foo/ext_emconf.php", "");
         myFixture.addFileToProject("foo/bar.txt", "");
 
-        myFixture.addFileToProject("foo/Configuration/RTE/Processing.yaml", "");
+        PsiFile psiFile = myFixture.addFileToProject("foo/Configuration/RTE/Processing.yaml", "");
 
         myFixture.configureByText(YAMLFileType.YML, "imports:\n" +
-                "  - { resource: \"EXT:foo/Configuration/RTE/<caret>Processing.yaml\" }';");
+                "  - { resource: \"EXT:foo<caret>/Configuration/RTE/Processing.yaml\" }';");
 
         PsiElement elementAtCaret = myFixture.getFile().findElementAt(myFixture.getCaretOffset()).getParent();
 


### PR DESCRIPTION
This adds the ability to reference `EXT:` strings in YAML files.

Example:

```yaml
imports:
    # this string will be clickable and offer autocompletion
    - { resource: "EXT:rte_ckeditor/Configuration/RTE/Processing.yaml" } 
```

Ref: #51 