### PR TITLE
Handle userFunc references

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ cache:
 
 matrix:
   include:
-  - env: IDEA_VERSION="IU-182.2757.3" PHP_PLUGIN_VERSION="182.2574.13" DEPLOY=true
+  - env: IDEA_VERSION="IU-182.2757.3" PHP_PLUGIN_VERSION="182.2574.13" PSI_VIEWER_PLUGIN_VERSION=182.2757.2 DEPLOY=true
 #  - env: IDEA_VERSION="IU-173.4127.17" PHP_PLUGIN_VERSION="173.4127.13"
 #  allow_failures:
 #  - env: IDEA_VERSION="IU-173.4127.17" PHP_PLUGIN_VERSION="173.4127.13"
@@ -25,6 +25,7 @@ before_install:
 - "export ORG_GRADLE_PROJECT_ideaVersion=${IDEA_VERSION}"
 - "export ORG_GRADLE_PROJECT_ideaType=${IDEA_TYPE}"
 - "export ORG_GRADLE_PROJECT_phpPluginVersion=${PHP_PLUGIN_VERSION}"
+- "export ORG_GRADLE_PROJECT_psiViewerPluginVersion=${PSI_VIEWER_PLUGIN_VERSION}"
 - java -version
 
 script:

--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,7 @@ buildscript {
 }
 
 plugins {
-    id "org.jetbrains.intellij" version "0.3.2"
-    id "de.undercouch.download" version "3.2.0"
+    id "org.jetbrains.intellij" version "0.3.3"
     id 'com.palantir.git-version' version "0.9.1"
 }
 
@@ -21,7 +20,14 @@ apply plugin: 'java'
 intellij {
     version ideaVersion
     pluginName 'TYPO3 CMS Plugin'
-    plugins = ["com.jetbrains.php:${phpPluginVersion}", 'CSS', 'java-i18n', 'properties', 'yaml']
+    plugins = [
+            "com.jetbrains.php:${phpPluginVersion}",
+            'CSS',
+            'java-i18n',
+            'properties',
+            'yaml',
+            "PsiViewer:${psiViewerPluginVersion}"
+    ]
     downloadSources !Boolean.valueOf(System.getenv('CI'))
 
     publishPlugin {
@@ -37,24 +43,6 @@ intellij {
 
 group 'com.cedricziel'
 version gitVersion()
-
-apply plugin: 'de.undercouch.download'
-task downloadPsiViewerPlugin() {
-    download {
-        src 'https://plugins.jetbrains.com/plugin/download?updateId=46431'
-        dest new File("${buildDir}/tmp/plugins/", 'PsiViewer.jar')
-        onlyIfNewer true
-    }
-}
-
-task copyPsiViewerPluginToSandBox(type: Copy) {
-    from "${buildDir}/tmp/plugins/PsiViewer.jar"
-    into "${buildDir}/idea-sandbox/plugins/"
-}
-
-copyPsiViewerPluginToSandBox.dependsOn downloadPsiViewerPlugin
-copyPsiViewerPluginToSandBox.mustRunAfter prepareSandbox
-runIde.dependsOn copyPsiViewerPluginToSandBox
 
 wrapper {
     gradleVersion '4.3.1'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 ideaVersion = IU-182.2757.3
 phpPluginVersion = 182.2574.13
+psiViewerPluginVersion = 182.2757.2
 #ideaVersion = IU-2018.1.4
 #phpPluginVersion = 181.5087.24
 #ideaVersion = IU-2017.3.3

--- a/src/main/java/com/cedricziel/idea/typo3/codeInspection/MissingColumnTypeInspection.java
+++ b/src/main/java/com/cedricziel/idea/typo3/codeInspection/MissingColumnTypeInspection.java
@@ -50,7 +50,7 @@ public class MissingColumnTypeInspection extends PhpInspection {
                 if (arrayIndex != null && arrayIndex.equals("type")) {
                     if (element instanceof StringLiteralExpression) {
                         String tableName = ((StringLiteralExpression) element).getContents();
-                        boolean isValidRenderType = TCAUtil.getAvailableColumnTypes(element).contains(tableName);
+                        boolean isValidRenderType = TCAUtil.getAvailableColumnTypes().contains(tableName);
 
                         if (!isValidRenderType) {
                             problemsHolder.registerProblem(element, "Missing column type definition");

--- a/src/main/java/com/cedricziel/idea/typo3/tca/TCAPatterns.java
+++ b/src/main/java/com/cedricziel/idea/typo3/tca/TCAPatterns.java
@@ -1,0 +1,73 @@
+package com.cedricziel.idea.typo3.tca;
+
+import com.intellij.patterns.ElementPattern;
+import com.intellij.patterns.PlatformPatterns;
+import com.intellij.patterns.PsiElementPattern;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.tree.IElementType;
+import com.jetbrains.php.lang.parser.PhpElementTypes;
+import com.jetbrains.php.lang.psi.elements.ArrayCreationExpression;
+import com.jetbrains.php.lang.psi.elements.ArrayHashElement;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+public class TCAPatterns {
+    @Contract(pure = true)
+    public static boolean isWizard(@NotNull ArrayCreationExpression expression) {
+
+        return isWizard().accepts(expression);
+    }
+
+    @Contract(pure = true)
+    public static PsiElementPattern.Capture<PsiElement> isWizard() {
+
+        return PlatformPatterns.psiElement()
+                .withSuperParent(5, arrayKeyWithString("wizards", PhpElementTypes.ARRAY_KEY));
+    }
+
+    public static boolean hasArrayHashElement(@NotNull ArrayCreationExpression expression, @NotNull String arrayKey) {
+
+        return hasArrayHashElementPattern(arrayKey, null).accepts(expression);
+    }
+
+    public static boolean hasArrayHashElement(@NotNull ArrayCreationExpression expression, @NotNull String arrayKey, String arrayValue) {
+
+        return hasArrayHashElementPattern(arrayKey, arrayValue).accepts(expression);
+    }
+
+    public static ElementPattern<PsiElement> hasArrayHashElementPattern(@NotNull String arrayKey, String arrayValue) {
+
+        if (arrayValue != null) {
+
+            return PlatformPatterns
+                    .and(
+                            PlatformPatterns.psiElement().withChild(
+                                    arrayKeyWithString(arrayKey, PhpElementTypes.ARRAY_KEY)
+                            ),
+                            PlatformPatterns.psiElement().withChild(
+                                    arrayKeyWithString(arrayValue, PhpElementTypes.ARRAY_VALUE)
+                            )
+                    );
+
+        }
+
+        return PlatformPatterns.psiElement().withChild(
+                arrayKeyWithString(arrayKey, PhpElementTypes.ARRAY_KEY)
+        );
+    }
+
+    private static PsiElementPattern.Capture<ArrayHashElement> arrayKeyWithString(@NotNull String arrayKey, IElementType arrayKey2) {
+        return PlatformPatterns.psiElement(ArrayHashElement.class).withChild(
+                elementWithStringLiteral(arrayKey2, arrayKey)
+        );
+    }
+
+    @NotNull
+    public static ElementPattern<PsiElement> elementWithStringLiteral(IElementType elementType, @NotNull String value) {
+
+        return PlatformPatterns.or(
+                PlatformPatterns.psiElement(elementType).withText("\"" + value + "\""),
+                PlatformPatterns.psiElement(elementType).withText("'" + value + "'")
+        );
+    }
+}

--- a/src/main/java/com/cedricziel/idea/typo3/tca/TCAPatterns.java
+++ b/src/main/java/com/cedricziel/idea/typo3/tca/TCAPatterns.java
@@ -110,6 +110,16 @@ public class TCAPatterns {
         return PlatformPatterns.psiElement().withParent(
                 PlatformPatterns.psiElement(StringLiteralExpression.class).withParent(
                         PlatformPatterns.or(
+                                // ['config' => ['<caret>']]
+                                PlatformPatterns.psiElement(PhpElementTypes.ARRAY_VALUE).withParent(
+                                        PlatformPatterns.psiElement(PhpElementTypes.ARRAY_CREATION_EXPRESSION).withParent(
+                                                PlatformPatterns.psiElement(PhpElementTypes.ARRAY_VALUE).withParent(
+                                                        PlatformPatterns.psiElement(ArrayHashElement.class).withChild(
+                                                                elementWithStringLiteral(PhpElementTypes.ARRAY_KEY, targetIndex)
+                                                        )
+                                                )
+                                        )
+                                ),
                                 // ['config' => ['<caret>' => '']]
                                 PlatformPatterns.psiElement(PhpElementTypes.ARRAY_KEY).withParent(
                                         PlatformPatterns.psiElement(ArrayHashElement.class).withParent(

--- a/src/main/java/com/cedricziel/idea/typo3/userFunc/UserFuncInsertHandler.java
+++ b/src/main/java/com/cedricziel/idea/typo3/userFunc/UserFuncInsertHandler.java
@@ -1,0 +1,17 @@
+package com.cedricziel.idea.typo3.userFunc;
+
+import com.intellij.codeInsight.completion.InsertHandler;
+import com.intellij.codeInsight.completion.InsertionContext;
+
+public class UserFuncInsertHandler implements InsertHandler<UserFuncLookupElement> {
+    private static final UserFuncInsertHandler INSTANCE = new UserFuncInsertHandler();
+
+    public static UserFuncInsertHandler getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public void handleInsert(InsertionContext context, UserFuncLookupElement item) {
+
+    }
+}

--- a/src/main/java/com/cedricziel/idea/typo3/userFunc/UserFuncLookupElement.java
+++ b/src/main/java/com/cedricziel/idea/typo3/userFunc/UserFuncLookupElement.java
@@ -1,0 +1,31 @@
+package com.cedricziel.idea.typo3.userFunc;
+
+import com.intellij.codeInsight.completion.InsertHandler;
+import com.intellij.codeInsight.completion.InsertionContext;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.stubs.StubIndexKey;
+import com.jetbrains.php.completion.PhpLookupElement;
+import com.jetbrains.php.lang.psi.elements.PhpNamedElement;
+import com.jetbrains.php.lang.psi.resolve.types.PhpType;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+
+public class UserFuncLookupElement extends PhpLookupElement {
+    public UserFuncLookupElement(@NotNull String name, @NotNull StubIndexKey indexKey, @NotNull Icon ico, PhpType phpType, @NotNull Project project, InsertHandler handler) {
+        super(name, indexKey, ico, phpType, project, handler);
+    }
+
+    public UserFuncLookupElement(@NotNull String name, @NotNull StubIndexKey indexKey, @NotNull Project project, InsertHandler handler) {
+        super(name, indexKey, project, handler);
+    }
+
+    public UserFuncLookupElement(@NotNull PhpNamedElement namedElement) {
+        super(namedElement);
+    }
+
+    @Override
+    public void handleInsert(InsertionContext context) {
+        UserFuncInsertHandler.getInstance().handleInsert(context, this);
+    }
+}

--- a/src/main/java/com/cedricziel/idea/typo3/userFunc/UserFuncPatterns.java
+++ b/src/main/java/com/cedricziel/idea/typo3/userFunc/UserFuncPatterns.java
@@ -6,6 +6,7 @@ import com.intellij.patterns.PsiElementPattern;
 import com.intellij.patterns.XmlPatterns;
 import com.intellij.psi.PsiElement;
 import com.jetbrains.php.lang.parser.PhpElementTypes;
+import com.jetbrains.php.lang.psi.elements.ConcatenationExpression;
 import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
 import org.jetbrains.annotations.NotNull;
 
@@ -14,6 +15,7 @@ public class UserFuncPatterns {
         return expectUserFuncReferenceXMLPattern().accepts(psiElement);
     }
 
+    @NotNull
     public static PsiElementPattern.Capture<PsiElement> expectUserFuncReferenceXMLPattern() {
         return XmlPatterns.psiElement().withParent(
                 XmlPatterns.xmlText().withParent(
@@ -27,15 +29,30 @@ public class UserFuncPatterns {
         );
     }
 
+    @NotNull
     public static ElementPattern<? extends PsiElement> expectUserFuncReferenceArrayValuePattern(@NotNull String arrayIndex) {
         return PlatformPatterns.psiElement(StringLiteralExpression.class).withParent(
-                PlatformPatterns.psiElement(PhpElementTypes.ARRAY_VALUE).withParent(
-                        PlatformPatterns.psiElement().withChild(
-                                PlatformPatterns.psiElement(PhpElementTypes.ARRAY_KEY).withChild(
-                                        PlatformPatterns.or(
-                                                PlatformPatterns.psiElement(StringLiteralExpression.class).withText("'" + arrayIndex + "'"),
-                                                PlatformPatterns.psiElement(StringLiteralExpression.class).withText("\"" + arrayIndex + "\"")
-                                        )
+                expectArrayKeyForValue(arrayIndex)
+        );
+    }
+
+    @NotNull
+    public static ElementPattern<? extends PsiElement> expectUserFuncReferenceStringConcatArrayValuePattern(@NotNull String arrayIndex) {
+        return PlatformPatterns.psiElement(StringLiteralExpression.class).withParent(
+                PlatformPatterns.psiElement(ConcatenationExpression.class).withParent(
+                        expectArrayKeyForValue(arrayIndex)
+                )
+        );
+    }
+
+    @NotNull
+    public static PsiElementPattern.Capture<PsiElement> expectArrayKeyForValue(@NotNull String arrayIndex) {
+        return PlatformPatterns.psiElement(PhpElementTypes.ARRAY_VALUE).withParent(
+                PlatformPatterns.psiElement().withChild(
+                        PlatformPatterns.psiElement(PhpElementTypes.ARRAY_KEY).withChild(
+                                PlatformPatterns.or(
+                                        PlatformPatterns.psiElement(StringLiteralExpression.class).withText("'" + arrayIndex + "'"),
+                                        PlatformPatterns.psiElement(StringLiteralExpression.class).withText("\"" + arrayIndex + "\"")
                                 )
                         )
                 )

--- a/src/main/java/com/cedricziel/idea/typo3/userFunc/UserFuncPatterns.java
+++ b/src/main/java/com/cedricziel/idea/typo3/userFunc/UserFuncPatterns.java
@@ -1,0 +1,42 @@
+package com.cedricziel.idea.typo3.userFunc;
+
+import com.intellij.patterns.ElementPattern;
+import com.intellij.patterns.PlatformPatterns;
+import com.intellij.patterns.PsiElementPattern;
+import com.intellij.patterns.XmlPatterns;
+import com.intellij.psi.PsiElement;
+import com.jetbrains.php.lang.parser.PhpElementTypes;
+import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
+import org.jetbrains.annotations.NotNull;
+
+public class UserFuncPatterns {
+    public static boolean expectUserFuncReferenceXML(@NotNull PsiElement psiElement) {
+        return expectUserFuncReferenceXMLPattern().accepts(psiElement);
+    }
+
+    public static PsiElementPattern.Capture<PsiElement> expectUserFuncReferenceXMLPattern() {
+        return XmlPatterns.psiElement().withParent(
+                XmlPatterns.xmlText().withParent(
+                        PlatformPatterns.or(
+                                XmlPatterns.xmlTag().withLocalName("userFunc"),
+                                XmlPatterns.xmlTag().withName("userFunc")
+                        )
+                )
+        );
+    }
+
+    public static ElementPattern<? extends PsiElement> expectUserFuncReferenceArrayValuePattern(@NotNull String arrayIndex) {
+        return PlatformPatterns.psiElement(StringLiteralExpression.class).withParent(
+                PlatformPatterns.psiElement(PhpElementTypes.ARRAY_VALUE).withParent(
+                        PlatformPatterns.psiElement().withChild(
+                                PlatformPatterns.psiElement(PhpElementTypes.ARRAY_KEY).withChild(
+                                        PlatformPatterns.or(
+                                                PlatformPatterns.psiElement(StringLiteralExpression.class).withText("'" + arrayIndex + "'"),
+                                                PlatformPatterns.psiElement(StringLiteralExpression.class).withText("\"" + arrayIndex + "\"")
+                                        )
+                                )
+                        )
+                )
+        );
+    }
+}

--- a/src/main/java/com/cedricziel/idea/typo3/userFunc/UserFuncPatterns.java
+++ b/src/main/java/com/cedricziel/idea/typo3/userFunc/UserFuncPatterns.java
@@ -19,7 +19,9 @@ public class UserFuncPatterns {
                 XmlPatterns.xmlText().withParent(
                         PlatformPatterns.or(
                                 XmlPatterns.xmlTag().withLocalName("userFunc"),
-                                XmlPatterns.xmlTag().withName("userFunc")
+                                XmlPatterns.xmlTag().withName("userFunc"),
+                                XmlPatterns.xmlTag().withLocalName("itemsProcFunc"),
+                                XmlPatterns.xmlTag().withName("itemsProcFunc")
                         )
                 )
         );

--- a/src/main/java/com/cedricziel/idea/typo3/userFunc/UserFuncReference.java
+++ b/src/main/java/com/cedricziel/idea/typo3/userFunc/UserFuncReference.java
@@ -1,0 +1,152 @@
+package com.cedricziel.idea.typo3.userFunc;
+
+import com.intellij.psi.PsiElementResolveResult;
+import com.intellij.psi.PsiPolyVariantReferenceBase;
+import com.intellij.psi.ResolveResult;
+import com.intellij.psi.xml.XmlText;
+import com.jetbrains.php.PhpIndex;
+import com.jetbrains.php.lang.psi.elements.Function;
+import com.jetbrains.php.lang.psi.elements.PhpNamedElement;
+import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
+import org.apache.commons.lang.StringUtils;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+
+public class UserFuncReference extends PsiPolyVariantReferenceBase {
+    private final String className;
+    private final String methodName;
+
+    public UserFuncReference(XmlText xmlText) {
+        super(xmlText);
+
+        String text = xmlText.getText();
+        if (text.contains("->")) {
+            String[] split = StringUtils.split(text, "->");
+
+            switch (split.length) {
+                case 0:
+                    className = null;
+                    methodName = null;
+                    break;
+                case 1:
+                    className = split[0].trim();
+                    methodName = null;
+                    break;
+                case 2:
+                    className = split[0].trim();
+                    methodName = split[1].trim();
+                    break;
+                default:
+                    className = null;
+                    methodName = null;
+            }
+        } else {
+            className = null;
+            methodName = text;
+        }
+    }
+
+    public UserFuncReference(StringLiteralExpression stringLiteralExpression) {
+        super(stringLiteralExpression);
+
+        String text = stringLiteralExpression.getContents();
+        if (text.contains("->")) {
+            String[] split = StringUtils.split(text, "->");
+
+            switch (split.length) {
+                case 0:
+                    className = null;
+                    methodName = null;
+                    break;
+                case 1:
+                    className = split[0].trim();
+                    methodName = null;
+                    break;
+                case 2:
+                    className = split[0].trim();
+                    methodName = split[1].trim();
+                    break;
+                default:
+                    className = null;
+                    methodName = null;
+            }
+        } else {
+            className = null;
+            methodName = text;
+        }
+    }
+
+    @NotNull
+    @Override
+    public ResolveResult[] multiResolve(boolean incompleteCode) {
+        if (this.methodName == null) {
+
+            return ResolveResult.EMPTY_ARRAY;
+        }
+
+        if (this.className == null) {
+            Collection<Function> functionsByName = PhpIndex.getInstance(myElement.getProject()).getFunctionsByName(methodName);
+
+            return PsiElementResolveResult.createResults(functionsByName);
+        }
+
+        String s = "#M#C\\" + this.className.replace("\\\\", "\\") + "." + this.methodName;
+        Collection<? extends PhpNamedElement> bySignature = PhpIndex.getInstance(myElement.getProject()).getBySignature(s);
+
+        return PsiElementResolveResult.createResults(bySignature);
+    }
+
+    @NotNull
+    @Override
+    public Object[] getVariants() {
+
+        List<Object> list = new ArrayList<>();
+        PhpIndex phpIndex = PhpIndex.getInstance(myElement.getProject());
+        Iterator<String> count = phpIndex.getAllFunctionNames(null).iterator();
+
+        while (true) {
+            while (count.hasNext()) {
+                String functionName = count.next();
+
+                phpIndex
+                        .getFunctionsByName(functionName)
+                        .stream()
+                        .map(UserFuncLookupElement::new)
+                        .forEach(list::add);
+            }
+
+            break;
+        }
+
+        if (className != null) {
+            phpIndex.getClassesByFQN(className).forEach(c -> {
+                c.getMethods()
+                        .stream()
+                        .filter(method -> method.getAccess().isPublic())
+                        .map(UserFuncLookupElement::new)
+                        .forEach(list::add);
+            });
+        }
+
+        Iterator<String> classes = phpIndex.getAllClassNames(null).iterator();
+        while (true) {
+            while (classes.hasNext()) {
+                String className = classes.next();
+
+                phpIndex
+                        .getFunctionsByName(className)
+                        .stream()
+                        .map(UserFuncLookupElement::new)
+                        .forEach(list::add);
+            }
+
+            break;
+        }
+
+        return list.toArray();
+    }
+}

--- a/src/main/java/com/cedricziel/idea/typo3/userFunc/UserFuncReference.java
+++ b/src/main/java/com/cedricziel/idea/typo3/userFunc/UserFuncReference.java
@@ -3,11 +3,10 @@ package com.cedricziel.idea.typo3.userFunc;
 import com.intellij.psi.PsiElementResolveResult;
 import com.intellij.psi.PsiPolyVariantReferenceBase;
 import com.intellij.psi.ResolveResult;
+import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.psi.xml.XmlText;
 import com.jetbrains.php.PhpIndex;
-import com.jetbrains.php.lang.psi.elements.Function;
-import com.jetbrains.php.lang.psi.elements.PhpNamedElement;
-import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
+import com.jetbrains.php.lang.psi.elements.*;
 import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
@@ -78,6 +77,31 @@ public class UserFuncReference extends PsiPolyVariantReferenceBase {
             className = null;
             methodName = text;
         }
+    }
+
+    public UserFuncReference(ConcatenationExpression element) {
+        super(element);
+
+        ClassConstantReference classRef = PsiTreeUtil.findChildOfType(element, ClassConstantReference.class);
+        StringLiteralExpression stringEl = PsiTreeUtil.findChildOfType(element, StringLiteralExpression.class);
+
+        if (classRef == null || stringEl == null) {
+            methodName = null;
+            className = null;
+
+            return;
+        }
+
+        className = classRef.getFQN();
+
+        String[] split = StringUtils.split(stringEl.getContents(), "->");
+        if (split.length == 0) {
+            methodName = null;
+
+            return;
+        }
+
+        methodName = split[0];
     }
 
     @NotNull

--- a/src/main/java/com/cedricziel/idea/typo3/userFunc/UserFuncReferenceContributor.java
+++ b/src/main/java/com/cedricziel/idea/typo3/userFunc/UserFuncReferenceContributor.java
@@ -1,5 +1,6 @@
 package com.cedricziel.idea.typo3.userFunc;
 
+import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.*;
 import com.intellij.psi.xml.XmlText;
 import com.intellij.util.ProcessingContext;
@@ -35,7 +36,16 @@ public class UserFuncReferenceContributor extends PsiReferenceContributor {
                     @Override
                     public PsiReference[] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
 
-                        return new PsiReference[]{new UserFuncReference((StringLiteralExpression) element)};
+                        StringLiteralExpression element1 = (StringLiteralExpression) element;
+                        if (element1.getContents().contains("->")) {
+                            int i = element1.getContents().indexOf("->");
+
+                            return new PsiReference[]{
+                                    new UserFuncReference(element1, new TextRange(i + 3, element1.getTextLength() - 1))
+                            };
+                        }
+
+                        return new PsiReference[]{new UserFuncReference(element1)};
                     }
                 }
         );
@@ -50,7 +60,16 @@ public class UserFuncReferenceContributor extends PsiReferenceContributor {
                     @Override
                     public PsiReference[] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
 
-                        return new PsiReference[]{new UserFuncReference((StringLiteralExpression) element)};
+                        StringLiteralExpression element1 = (StringLiteralExpression) element;
+                        if (element1.getContents().contains("->")) {
+                            int i = element1.getContents().indexOf("->");
+
+                            return new PsiReference[]{
+                                    new UserFuncReference(element1, new TextRange(i + 3, element1.getTextLength() - 1))
+                            };
+                        }
+
+                        return new PsiReference[]{new UserFuncReference(element1)};
                     }
                 }
         );
@@ -65,7 +84,17 @@ public class UserFuncReferenceContributor extends PsiReferenceContributor {
                     @Override
                     public PsiReference[] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
 
-                        return new PsiReference[]{new UserFuncReference((ConcatenationExpression) element.getParent())};
+                        ConcatenationExpression parent = (ConcatenationExpression) element.getParent();
+                        StringLiteralExpression element1 = (StringLiteralExpression) element;
+                        if (element1.getContents().contains("->")) {
+                            int i = element1.getContents().indexOf("->");
+
+                            return new PsiReference[]{
+                                    new UserFuncReference(element1, new TextRange(i + 3, element1.getTextLength() - 1), parent)
+                            };
+                        }
+
+                        return PsiReference.EMPTY_ARRAY;
                     }
                 }
         );
@@ -80,7 +109,17 @@ public class UserFuncReferenceContributor extends PsiReferenceContributor {
                     @Override
                     public PsiReference[] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
 
-                        return new PsiReference[]{new UserFuncReference((ConcatenationExpression) element.getParent())};
+                        ConcatenationExpression parent = (ConcatenationExpression) element.getParent();
+                        StringLiteralExpression element1 = (StringLiteralExpression) element;
+                        if (element1.getContents().contains("->")) {
+                            int i = element1.getContents().indexOf("->");
+
+                            return new PsiReference[]{
+                                    new UserFuncReference(element1, new TextRange(i + 3, element1.getTextLength() - 1), parent)
+                            };
+                        }
+
+                        return PsiReference.EMPTY_ARRAY;
                     }
                 }
         );

--- a/src/main/java/com/cedricziel/idea/typo3/userFunc/UserFuncReferenceContributor.java
+++ b/src/main/java/com/cedricziel/idea/typo3/userFunc/UserFuncReferenceContributor.java
@@ -1,0 +1,61 @@
+package com.cedricziel.idea.typo3.userFunc;
+
+import com.intellij.psi.*;
+import com.intellij.psi.xml.XmlText;
+import com.intellij.util.ProcessingContext;
+import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
+import org.jetbrains.annotations.NotNull;
+
+public class UserFuncReferenceContributor extends PsiReferenceContributor {
+    @Override
+    public void registerReferenceProviders(@NotNull PsiReferenceRegistrar registrar) {
+        /*
+         * <userFunc>My\Extension\Foo\Bar->method</userFunc>
+         */
+        registrar.registerReferenceProvider(
+                UserFuncPatterns.expectUserFuncReferenceXMLPattern(),
+                new PsiReferenceProvider() {
+                    @NotNull
+                    @Override
+                    public PsiReference[] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
+                        if (!(element.getParent() instanceof XmlText)) {
+                            return PsiReference.EMPTY_ARRAY;
+                        }
+
+                        XmlText text = (XmlText) element.getParent();
+                        return new PsiReference[]{new UserFuncReference(text)};
+                    }
+                }
+        );
+
+        /*
+         * ['userFunc' => 'My\Extension\Foo\Bar->method']
+         */
+        registrar.registerReferenceProvider(
+                UserFuncPatterns.expectUserFuncReferenceArrayValuePattern("userFunc"),
+                new PsiReferenceProvider() {
+                    @NotNull
+                    @Override
+                    public PsiReference[] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
+
+                        return new PsiReference[]{new UserFuncReference((StringLiteralExpression) element)};
+                    }
+                }
+        );
+
+        /*
+         * ['itemsProcFunc' => 'My\Extension\Foo\Bar->method']
+         */
+        registrar.registerReferenceProvider(
+                UserFuncPatterns.expectUserFuncReferenceArrayValuePattern("itemsProcFunc"),
+                new PsiReferenceProvider() {
+                    @NotNull
+                    @Override
+                    public PsiReference[] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
+
+                        return new PsiReference[]{new UserFuncReference((StringLiteralExpression) element)};
+                    }
+                }
+        );
+    }
+}

--- a/src/main/java/com/cedricziel/idea/typo3/userFunc/UserFuncReferenceContributor.java
+++ b/src/main/java/com/cedricziel/idea/typo3/userFunc/UserFuncReferenceContributor.java
@@ -3,6 +3,7 @@ package com.cedricziel.idea.typo3.userFunc;
 import com.intellij.psi.*;
 import com.intellij.psi.xml.XmlText;
 import com.intellij.util.ProcessingContext;
+import com.jetbrains.php.lang.psi.elements.ConcatenationExpression;
 import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
 import org.jetbrains.annotations.NotNull;
 
@@ -55,16 +56,16 @@ public class UserFuncReferenceContributor extends PsiReferenceContributor {
         );
 
         /*
-         * ['itemsProcFunc' => My\Extension\Foo\Bar::class . '->method']
+         * ['userFunc' => My\Extension\Foo\Bar::class . '->method']
          */
         registrar.registerReferenceProvider(
-                UserFuncPatterns.expectUserFuncReferenceArrayValuePattern("userFunc"),
+                UserFuncPatterns.expectUserFuncReferenceStringConcatArrayValuePattern("userFunc"),
                 new PsiReferenceProvider() {
                     @NotNull
                     @Override
                     public PsiReference[] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
 
-                        return new PsiReference[]{new UserFuncReference((StringLiteralExpression) element)};
+                        return new PsiReference[]{new UserFuncReference((ConcatenationExpression) element.getParent())};
                     }
                 }
         );
@@ -73,13 +74,13 @@ public class UserFuncReferenceContributor extends PsiReferenceContributor {
          * ['itemsProcFunc' => My\Extension\Foo\Bar::class . '->method']
          */
         registrar.registerReferenceProvider(
-                UserFuncPatterns.expectUserFuncReferenceArrayValuePattern("itemsProcFunc"),
+                UserFuncPatterns.expectUserFuncReferenceStringConcatArrayValuePattern("itemsProcFunc"),
                 new PsiReferenceProvider() {
                     @NotNull
                     @Override
                     public PsiReference[] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
 
-                        return new PsiReference[]{new UserFuncReference((StringLiteralExpression) element)};
+                        return new PsiReference[]{new UserFuncReference((ConcatenationExpression) element.getParent())};
                     }
                 }
         );

--- a/src/main/java/com/cedricziel/idea/typo3/userFunc/UserFuncReferenceContributor.java
+++ b/src/main/java/com/cedricziel/idea/typo3/userFunc/UserFuncReferenceContributor.java
@@ -18,12 +18,8 @@ public class UserFuncReferenceContributor extends PsiReferenceContributor {
                     @NotNull
                     @Override
                     public PsiReference[] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
-                        if (!(element.getParent() instanceof XmlText)) {
-                            return PsiReference.EMPTY_ARRAY;
-                        }
 
-                        XmlText text = (XmlText) element.getParent();
-                        return new PsiReference[]{new UserFuncReference(text)};
+                        return new PsiReference[]{new UserFuncReference((XmlText) element.getParent())};
                     }
                 }
         );
@@ -45,6 +41,36 @@ public class UserFuncReferenceContributor extends PsiReferenceContributor {
 
         /*
          * ['itemsProcFunc' => 'My\Extension\Foo\Bar->method']
+         */
+        registrar.registerReferenceProvider(
+                UserFuncPatterns.expectUserFuncReferenceArrayValuePattern("itemsProcFunc"),
+                new PsiReferenceProvider() {
+                    @NotNull
+                    @Override
+                    public PsiReference[] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
+
+                        return new PsiReference[]{new UserFuncReference((StringLiteralExpression) element)};
+                    }
+                }
+        );
+
+        /*
+         * ['itemsProcFunc' => My\Extension\Foo\Bar::class . '->method']
+         */
+        registrar.registerReferenceProvider(
+                UserFuncPatterns.expectUserFuncReferenceArrayValuePattern("userFunc"),
+                new PsiReferenceProvider() {
+                    @NotNull
+                    @Override
+                    public PsiReference[] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
+
+                        return new PsiReference[]{new UserFuncReference((StringLiteralExpression) element)};
+                    }
+                }
+        );
+
+        /*
+         * ['itemsProcFunc' => My\Extension\Foo\Bar::class . '->method']
          */
         registrar.registerReferenceProvider(
                 UserFuncPatterns.expectUserFuncReferenceArrayValuePattern("itemsProcFunc"),

--- a/src/main/java/com/cedricziel/idea/typo3/util/TCAUtil.java
+++ b/src/main/java/com/cedricziel/idea/typo3/util/TCAUtil.java
@@ -11,6 +11,8 @@ import com.jetbrains.php.PhpIndex;
 import com.jetbrains.php.lang.parser.PhpElementTypes;
 import com.jetbrains.php.lang.psi.elements.PhpClass;
 import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
+import gnu.trove.THashSet;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 
@@ -63,6 +65,135 @@ public class TCAUtil {
             "rows",
     };
 
+    public static final String[] TCA_DEFAULT_EVALUATIONS = {
+            "alpha",
+            "alphanum",
+            "alphanum_x",
+            "date",
+            "datetime",
+            "domainname",
+            "double2",
+            "int",
+            "is_in",
+            "lower",
+            "md5",
+            "nospace",
+            "null",
+            "num",
+            "password",
+            "required",
+            "time",
+            "timesec",
+            "trim",
+            "unique",
+            "uniqueInPid",
+            "upper",
+            "year",
+    };
+
+    public static final String[] TCA_CONFIG_SECTION_CHILDREN = {
+            "appearance",
+            "allowNonIdValues",
+            "authMode",
+            "authMode_enforce",
+            "autoSizeMax",
+            "allowed",
+            "behaviour",
+            "checkbox",
+            "cols",
+            "dbType",
+            "default",
+            "disableNoMatchingValueElement",
+            "disable_controls",
+            "disallowed",
+            "dontRemapTablesOnCopy",
+            "ds",
+            "ds_tableField",
+            "ds_pointerField",
+            "ds_pointerField_searchParent",
+            "ds_pointerField_searchParent_subField",
+            "enableMultiSelectFilterTextfield",
+            "exclusiveKeys",
+            "eval",
+            "items",
+            "itemsProcFunc",
+            "itemListStyle",
+            "filter",
+            "fixedRows",
+            "fieldWizard",
+            "fileFolder",
+            "fileFolder_extList",
+            "fileFolder_recursions",
+            "form_type",
+            "format",
+            "foreign_match_fields",
+            "foreign_default_sortby",
+            "foreign_field",
+            "foreign_label",
+            "foreign_record_defaults",
+            "foreign_sortby",
+            "foreign_selector",
+            "foreign_selector_fieldTcaOverride",
+            "foreign_table",
+            "foreign_table_field",
+            "foreign_table_loadIcons",
+            "foreign_table_prefix",
+            "foreign_table_where",
+            "foreign_types",
+            "foreign_unique",
+            "is_in",
+            "internal_type",
+            "iconsInOptionTags",
+            "localizeReferencesAtParentLocalization",
+            "max",
+            "mode",
+            "MM",
+            "MM_oppositeUsage",
+            "MM_hasUidField",
+            "MM_insert_fields",
+            "MM_match_fields",
+            "MM_opposite_field",
+            "MM_table_where",
+            "maxitems",
+            "minitems",
+            "max_size",
+            "multiple",
+            "multiSelectFilterItems",
+            "neg_foreign_table",
+            "noTableWrapping",
+            "noIconsBelowSelect",
+            "parameters",
+            "pass_content",
+            "placeholder",
+            "prepend_tname",
+            "range",
+            "renderType",
+            "renderMode",
+            "rootLevel",
+            "rows",
+            "show_thumbs",
+            "selicon_cols",
+            "search",
+            "selectedListStyle",
+            "showIfRte",
+            "size",
+            "softref",
+            "special",
+            "suppress_icons",
+            "symmetric_field",
+            "symmetric_label",
+            "symmetric_sortby",
+            "readOnly",
+            "treeConfig",
+            "type",
+            "userFunc",
+            "uploadfolder",
+            "validation",
+            "wizards",
+            "wrap",
+    };
+
+
     private static final String EXT_LOCALCONF_FILENAME = "ext_localconf.php";
 
     private static final String NODE_FACTORY_CLASS = "TYPO3\\CMS\\Backend\\Form\\NodeFactory";
@@ -90,7 +221,7 @@ public class TCAUtil {
         return renderTypes;
     }
 
-    public static Set<String> getAvailableColumnTypes(PsiElement element) {
+    public static Set<String> getAvailableColumnTypes() {
 
         return new HashSet<>(Arrays.asList(TCA_CORE_TYPES));
     }
@@ -154,5 +285,17 @@ public class TCAUtil {
                                 )
                 )
                 .accepts(element);
+    }
+
+    @NotNull
+    public static Set<String> getAvailableEvaluations() {
+        Set<String> evaluations = new THashSet<>();
+        evaluations.addAll(Arrays.asList(TCA_DEFAULT_EVALUATIONS));
+
+        return evaluations;
+    }
+
+    public static String[] getConfigSectionChildren() {
+        return TCA_CONFIG_SECTION_CHILDREN;
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -122,6 +122,7 @@ It is a great inspiration for possible solutions and parts of the code.</p>
 <ul>
   <li>Complete sub keys of TCA config section</li>
   <li>Complete available TCA evaluations</li>
+  <li>Reference (complete, navigate) userFuncs</li>
 </ul>
 
     ]]>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -120,7 +120,8 @@ It is a great inspiration for possible solutions and parts of the code.</p>
     <change-notes><![CDATA[
 
 <ul>
-  <li>Infer types from ObjectStorage properties</li>
+  <li>Complete sub keys of TCA config section</li>
+  <li>Complete available TCA evaluations</li>
 </ul>
 
     ]]>
@@ -170,8 +171,7 @@ It is a great inspiration for possible solutions and parts of the code.</p>
 
 
         <!-- completion -->
-        <completion.contributor language="PHP"
-                                implementationClass="com.cedricziel.idea.typo3.tca.codeInsight.TCACompletionContributor"/>
+        <completion.contributor language="PHP" implementationClass="com.cedricziel.idea.typo3.tca.codeInsight.TCACompletionContributor"/>
 
         <!-- annotation -->
         <annotator language="PHP" implementationClass="com.cedricziel.idea.typo3.annotation.IconAnnotator"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -216,6 +216,9 @@ It is a great inspiration for possible solutions and parts of the code.</p>
 
         <!-- extbase persistence -->
         <completion.contributor language="PHP" implementationClass="com.cedricziel.idea.typo3.extbase.persistence.ExtbasePersistenceCompletionContributor"/>
+
+        <!-- userFunc -->
+        <psi.referenceContributor implementation="com.cedricziel.idea.typo3.userFunc.UserFuncReferenceContributor"/>
     </extensions>
 
     <actions>

--- a/src/test/java/com/cedricziel/idea/typo3/tca/codeInsight/TCACompletionContributorTest.java
+++ b/src/test/java/com/cedricziel/idea/typo3/tca/codeInsight/TCACompletionContributorTest.java
@@ -1,0 +1,118 @@
+package com.cedricziel.idea.typo3.tca.codeInsight;
+
+import com.cedricziel.idea.typo3.AbstractTestCase;
+import com.cedricziel.idea.typo3.util.TCAUtil;
+import com.intellij.codeInsight.completion.CompletionType;
+import com.jetbrains.php.lang.PhpFileType;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class TCACompletionContributorTest extends AbstractTestCase {
+
+    public void testCanCompleteRenderTypes() {
+        List<String> lookupElementStrings;
+
+        myFixture.configureByText(PhpFileType.INSTANCE, "<?php $foo = ['renderType' => '<caret>'];");
+        myFixture.complete(CompletionType.BASIC);
+        lookupElementStrings = myFixture.getLookupElementStrings();
+        assertTrue("Can complete empty value", lookupElementStrings.contains("selectSingle"));
+
+        myFixture.configureByText(PhpFileType.INSTANCE, "<?php $foo = ['renderType' => 's<caret>'];");
+        myFixture.complete(CompletionType.BASIC);
+        lookupElementStrings = myFixture.getLookupElementStrings();
+        assertTrue("Can complete partial value", lookupElementStrings.contains("selectSingle"));
+
+        myFixture.configureByText(PhpFileType.INSTANCE, "<?php $GLOBALS['renderType'] = '<caret>'];");
+        myFixture.complete(CompletionType.BASIC);
+        lookupElementStrings = myFixture.getLookupElementStrings();
+        assertTrue("Can complete empty value", lookupElementStrings.contains("selectSingle"));
+
+        myFixture.configureByText(PhpFileType.INSTANCE, "<?php $GLOBALS['renderType'] = 's<caret>'];");
+        myFixture.complete(CompletionType.BASIC);
+        lookupElementStrings = myFixture.getLookupElementStrings();
+        assertTrue("Can complete partial value", lookupElementStrings.contains("selectSingle"));
+    }
+
+    public void testCanCompleteTypes() {
+        List<String> lookupElementStrings;
+
+        myFixture.configureByText(PhpFileType.INSTANCE, "<?php $foo = ['type' => '<caret>'];");
+        myFixture.complete(CompletionType.BASIC);
+        lookupElementStrings = myFixture.getLookupElementStrings();
+        assertTrue("Can complete empty value", lookupElementStrings.contains("text"));
+
+        myFixture.configureByText(PhpFileType.INSTANCE, "<?php $foo = ['type' => 't<caret>'];");
+        myFixture.complete(CompletionType.BASIC);
+        lookupElementStrings = myFixture.getLookupElementStrings();
+        assertTrue("Can complete partial value", lookupElementStrings.contains("text"));
+
+        myFixture.configureByText(PhpFileType.INSTANCE, "<?php $GLOBALS['type'] = '<caret>'];");
+        myFixture.complete(CompletionType.BASIC);
+        lookupElementStrings = myFixture.getLookupElementStrings();
+        assertTrue("Can complete empty value", lookupElementStrings.contains("text"));
+
+        myFixture.configureByText(PhpFileType.INSTANCE, "<?php $GLOBALS['type'] = 't<caret>'];");
+        myFixture.complete(CompletionType.BASIC);
+        lookupElementStrings = myFixture.getLookupElementStrings();
+        assertTrue("Can complete partial value", lookupElementStrings.contains("text"));
+    }
+
+    public void testCanCompleteTCAEvaluations() {
+        List<String> lookupElementStrings;
+
+        myFixture.configureByText(PhpFileType.INSTANCE, "<?php $foo = ['eval' => '<caret>'];");
+        myFixture.complete(CompletionType.BASIC);
+        lookupElementStrings = myFixture.getLookupElementStrings();
+        assertTrue("Can complete empty value", lookupElementStrings.contains("trim"));
+
+        myFixture.configureByText(PhpFileType.INSTANCE, "<?php $foo = ['eval' => 't<caret>'];");
+        myFixture.complete(CompletionType.BASIC);
+        lookupElementStrings = myFixture.getLookupElementStrings();
+        assertTrue("Can complete partial value", lookupElementStrings.contains("trim"));
+
+        myFixture.configureByText(PhpFileType.INSTANCE, "<?php $foo = ['eval' => 'alpha,<caret>'];");
+        myFixture.complete(CompletionType.BASIC);
+        lookupElementStrings = myFixture.getLookupElementStrings();
+        assertTrue("Can complete csv separated value", lookupElementStrings.contains("alpha,trim"));
+
+        myFixture.configureByText(PhpFileType.INSTANCE, "<?php $GLOBALS['eval'] = '<caret>'];");
+        myFixture.complete(CompletionType.BASIC);
+        lookupElementStrings = myFixture.getLookupElementStrings();
+        assertTrue("Can complete empty value", lookupElementStrings.contains("trim"));
+
+        myFixture.configureByText(PhpFileType.INSTANCE, "<?php $GLOBALS['eval'] = 't<caret>'];");
+        myFixture.complete(CompletionType.BASIC);
+        lookupElementStrings = myFixture.getLookupElementStrings();
+        assertTrue("Can complete partial value", lookupElementStrings.contains("trim"));
+
+        myFixture.configureByText(PhpFileType.INSTANCE, "<?php $GLOBALS['eval'] = 'alpha,<caret>'];");
+        myFixture.complete(CompletionType.BASIC);
+        lookupElementStrings = myFixture.getLookupElementStrings();
+        assertTrue("Can complete csv separated value", lookupElementStrings.contains("alpha,trim"));
+    }
+
+    public void testCanCompleteTCAConfigSectionIndexes() {
+        List<String> lookupElementStrings;
+
+        myFixture.configureByText(PhpFileType.INSTANCE, "<?php $GLOBALS['config'][\"<caret>\"] = '';");
+        myFixture.complete(CompletionType.BASIC);
+        lookupElementStrings = myFixture.getLookupElementStrings();
+        assertTrue("Can complete empty value", lookupElementStrings.containsAll(Arrays.asList(TCAUtil.TCA_CONFIG_SECTION_CHILDREN)));
+
+        myFixture.configureByText(PhpFileType.INSTANCE, "<?php $GLOBALS['config']['r<caret>'] = '';");
+        myFixture.complete(CompletionType.BASIC);
+        lookupElementStrings = myFixture.getLookupElementStrings();
+        assertTrue("Can complete partial value", lookupElementStrings.contains("renderType"));
+
+        myFixture.configureByText(PhpFileType.INSTANCE, "<?php $foo = ['config' => ['<caret>' => '']];");
+        myFixture.complete(CompletionType.BASIC);
+        lookupElementStrings = myFixture.getLookupElementStrings();
+        assertTrue("Can complete empty value", lookupElementStrings.containsAll(Arrays.asList(TCAUtil.TCA_CONFIG_SECTION_CHILDREN)));
+
+        myFixture.configureByText(PhpFileType.INSTANCE, "<?php $foo = ['config' => ['r<caret>' => ''];");
+        myFixture.complete(CompletionType.BASIC);
+        lookupElementStrings = myFixture.getLookupElementStrings();
+        assertTrue("Can complete partial value", lookupElementStrings.contains("renderType"));
+    }
+}

--- a/src/test/java/com/cedricziel/idea/typo3/tca/codeInsight/TCACompletionContributorTest.java
+++ b/src/test/java/com/cedricziel/idea/typo3/tca/codeInsight/TCACompletionContributorTest.java
@@ -114,5 +114,15 @@ public class TCACompletionContributorTest extends AbstractTestCase {
         myFixture.complete(CompletionType.BASIC);
         lookupElementStrings = myFixture.getLookupElementStrings();
         assertTrue("Can complete partial value", lookupElementStrings.contains("renderType"));
+
+        myFixture.configureByText(PhpFileType.INSTANCE, "<?php $foo = ['config' => ['<caret>']];");
+        myFixture.complete(CompletionType.BASIC);
+        lookupElementStrings = myFixture.getLookupElementStrings();
+        assertTrue("Can complete empty value", lookupElementStrings.containsAll(Arrays.asList(TCAUtil.TCA_CONFIG_SECTION_CHILDREN)));
+
+        myFixture.configureByText(PhpFileType.INSTANCE, "<?php $foo = ['config' => ['r<caret>'];");
+        myFixture.complete(CompletionType.BASIC);
+        lookupElementStrings = myFixture.getLookupElementStrings();
+        assertTrue("Can complete partial value", lookupElementStrings.contains("renderType"));
     }
 }

--- a/src/test/java/com/cedricziel/idea/typo3/userFunc/UserFuncReferenceContributorTest.java
+++ b/src/test/java/com/cedricziel/idea/typo3/userFunc/UserFuncReferenceContributorTest.java
@@ -1,0 +1,44 @@
+package com.cedricziel.idea.typo3.userFunc;
+
+import com.cedricziel.idea.typo3.AbstractTestCase;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiReference;
+
+public class UserFuncReferenceContributorTest extends AbstractTestCase {
+
+    public void testCanCreateUserFuncReferencesOnXmlStrings() {
+        PsiFile file = myFixture.configureByText(
+                "foo.xml",
+                "<userFunc>coun<caret>t</userFunc>"
+        );
+
+        PsiElement elementAtCaret = file.findElementAt(myFixture.getCaretOffset());
+        PsiReference[] references = elementAtCaret.getReferences();
+        for (PsiReference reference: references) {
+            if (reference instanceof UserFuncReference) {
+                return;
+            }
+        }
+
+        fail("No UserFuncReference found");
+    }
+
+    public void testCanCreateUserFuncReferencesOnPHPArrays() {
+        PsiFile file = myFixture.configureByText(
+                "foo.php",
+                "<?php \n" +
+                        "$foo = ['userFunc' => 'coun<caret>t'];"
+        );
+
+        PsiElement elementAtCaret = file.findElementAt(myFixture.getCaretOffset()).getParent();
+        PsiReference[] references = elementAtCaret.getReferences();
+        for (PsiReference reference: references) {
+            if (reference instanceof UserFuncReference) {
+                return;
+            }
+        }
+
+        fail("No UserFuncReference found");
+    }
+}

--- a/src/test/java/com/cedricziel/idea/typo3/userFunc/UserFuncReferenceContributorTest.java
+++ b/src/test/java/com/cedricziel/idea/typo3/userFunc/UserFuncReferenceContributorTest.java
@@ -44,8 +44,24 @@ public class UserFuncReferenceContributorTest extends AbstractTestCase {
     public void testCanCreateUserFuncReferencesOnPHPArrays() {
         PsiFile file = myFixture.configureByText(
                 "foo.php",
-                "<?php \n" +
-                        "$foo = ['userFunc' => 'coun<caret>t'];"
+                "<?php $foo = ['userFunc' => 'coun<caret>t'];"
+        );
+
+        PsiElement elementAtCaret = file.findElementAt(myFixture.getCaretOffset()).getParent();
+        PsiReference[] references = elementAtCaret.getReferences();
+        for (PsiReference reference: references) {
+            if (reference instanceof UserFuncReference) {
+                return;
+            }
+        }
+
+        fail("No UserFuncReference found");
+    }
+
+    public void testCanCreateUserFuncReferencesOnConcatenationExpressionsInPHPArrays() {
+        PsiFile file = myFixture.configureByText(
+                "foo.php",
+                "<?php \n$foo = ['userFunc' => \\Foo\\Bar::class . '->coun<caret>t'];"
         );
 
         PsiElement elementAtCaret = file.findElementAt(myFixture.getCaretOffset()).getParent();

--- a/src/test/java/com/cedricziel/idea/typo3/userFunc/UserFuncReferenceContributorTest.java
+++ b/src/test/java/com/cedricziel/idea/typo3/userFunc/UserFuncReferenceContributorTest.java
@@ -24,6 +24,23 @@ public class UserFuncReferenceContributorTest extends AbstractTestCase {
         fail("No UserFuncReference found");
     }
 
+    public void testCanCreateItemsProcFuncReferencesOnXmlStrings() {
+        PsiFile file = myFixture.configureByText(
+                "foo.xml",
+                "<itemsProcFunc>coun<caret>t</itemsProcFunc>"
+        );
+
+        PsiElement elementAtCaret = file.findElementAt(myFixture.getCaretOffset());
+        PsiReference[] references = elementAtCaret.getReferences();
+        for (PsiReference reference: references) {
+            if (reference instanceof UserFuncReference) {
+                return;
+            }
+        }
+
+        fail("No UserFuncReference found");
+    }
+
     public void testCanCreateUserFuncReferencesOnPHPArrays() {
         PsiFile file = myFixture.configureByText(
                 "foo.php",

--- a/src/test/java/com/cedricziel/idea/typo3/userFunc/UserFuncReferenceTest.java
+++ b/src/test/java/com/cedricziel/idea/typo3/userFunc/UserFuncReferenceTest.java
@@ -1,0 +1,69 @@
+package com.cedricziel.idea.typo3.userFunc;
+
+import com.cedricziel.idea.typo3.AbstractTestCase;
+import com.jetbrains.php.lang.psi.elements.Function;
+import com.jetbrains.php.lang.psi.elements.Method;
+
+public class UserFuncReferenceTest extends AbstractTestCase {
+
+    @Override
+    protected String getTestDataPath() {
+        return "testData/com/cedricziel/idea/typo3/userFunc";
+    }
+
+    public void testReferenceCanResolveDefinition() {
+        myFixture.copyFileToProject("classes.php");
+
+        assertResolvesTo(
+                "bar.php",
+                "<?php \n['userFunc' => 'Foo\\Bar->q<caret>ux'];",
+                UserFuncReference.class,
+                Method.class,
+                "A class method can be resolved"
+        );
+
+        assertResolvesTo(
+                "bar.php",
+                "<?php \n['userFunc' => 'coun<caret>t'];",
+                UserFuncReference.class,
+                Function.class,
+                "A global function can be resolved"
+        );
+
+        assertResolvesTo(
+                "bar.php",
+                "<?php \n['userFunc' => 'user_calc_my_stuf<caret>f'];",
+                UserFuncReference.class,
+                Function.class,
+                "A global function can be resolved"
+        );
+    }
+
+    public void testReferenceCanResolveVariants() {
+        myFixture.copyFileToProject("classes.php");
+
+        assertHasVariant(
+                "foo.php",
+                "<?php \n['userFunc' => 'Foo\\Bar->q<caret>'];",
+                "quo",
+                UserFuncReference.class,
+                "Reference can correctly resolve public methods as variants"
+        );
+
+        assertHasVariant(
+                "foo.php",
+                "<?php \n['userFunc' => 'Foo\\Bar->q<caret>'];",
+                "qux",
+                UserFuncReference.class,
+                "Reference can correctly resolve static methods as variants"
+        );
+
+        assertNotHasVariant(
+                "foo.php",
+                "<?php \n['userFunc' => 'Foo\\Bar->q<caret>'];",
+                "invisible",
+                UserFuncReference.class,
+                "Reference does not present inaccessible variants (non public methods)"
+        );
+    }
+}

--- a/src/test/java/com/cedricziel/idea/typo3/userFunc/UserFuncReferenceTest.java
+++ b/src/test/java/com/cedricziel/idea/typo3/userFunc/UserFuncReferenceTest.java
@@ -37,6 +37,14 @@ public class UserFuncReferenceTest extends AbstractTestCase {
                 Function.class,
                 "A global function can be resolved"
         );
+
+        assertResolvesTo(
+                "bar.php",
+                "<?php \n['userFunc' => Foo\\Bar::class . '->q<caret>ux'];",
+                UserFuncReference.class,
+                Method.class,
+                "A class method can be resolved through concatenation"
+        );
     }
 
     public void testReferenceCanResolveVariants() {
@@ -58,12 +66,36 @@ public class UserFuncReferenceTest extends AbstractTestCase {
                 "Reference can correctly resolve static methods as variants"
         );
 
+        assertHasVariant(
+                "foo.php",
+                "<?php \n['userFunc' => Foo\\Bar::class . '->q<caret>'];",
+                "quo",
+                UserFuncReference.class,
+                "Reference can correctly resolve public methods as variants on concatenation expression"
+        );
+
+        assertHasVariant(
+                "foo.php",
+                "<?php \n['userFunc' => Foo\\Bar::class . '->q<caret>'];",
+                "qux",
+                UserFuncReference.class,
+                "Reference can correctly resolve static methods as variants on concatenation expression"
+        );
+
         assertNotHasVariant(
                 "foo.php",
                 "<?php \n['userFunc' => 'Foo\\Bar->q<caret>'];",
                 "invisible",
                 UserFuncReference.class,
                 "Reference does not present inaccessible variants (non public methods)"
+        );
+
+        assertNotHasVariant(
+                "foo.php",
+                "<?php \n['userFunc' => Foo\\Bar::class . '->q<caret>'];",
+                "invisible",
+                UserFuncReference.class,
+                "Reference does not present inaccessible variants (non public methods) on concatenation expression"
         );
     }
 }

--- a/testData/com/cedricziel/idea/typo3/userFunc/classes.php
+++ b/testData/com/cedricziel/idea/typo3/userFunc/classes.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace {
+    function count()
+    {
+
+    }
+
+    function user_calc_my_stuff()
+    {
+
+    }
+}
+
+namespace Foo {
+    class Bar
+    {
+        public static function quo()
+        {
+
+        }
+
+        public function qux()
+        {
+
+        }
+
+        private function invisible()
+        {
+
+        }
+    }
+}

--- a/testData/com/cedricziel/idea/typo3/userFunc/foo.php
+++ b/testData/com/cedricziel/idea/typo3/userFunc/foo.php
@@ -1,0 +1,3 @@
+<?php
+
+['userFunc' => 'count'];


### PR DESCRIPTION
Enable code navigation between usage and definition in:

**PHP:**

```php
['userFunc' => 'my_function'],
['itemsProcFunc' => 'my_function'],
```

**XML:**

```xml
<userFunc>my_function</userFunc>
<itemsProcFunc>myFunction</userFunc>
```

Handling TypoScript will be possible, once the TypoScript plugin is compatible.

Closes: #188 