### PR TITLE
Live template for f:for

### DIFF
--- a/lang-fluid/build.gradle
+++ b/lang-fluid/build.gradle
@@ -16,6 +16,8 @@ buildscript {
 import org.jetbrains.grammarkit.tasks.GenerateLexer
 import org.jetbrains.grammarkit.tasks.GenerateParser
 
+def htmlFixer = { htmlFile -> file(htmlFile).text.replace('<html>', '').replace('</html>', '') }
+
 def genRoot = file('gen')
 sourceSets {
     main {
@@ -44,6 +46,18 @@ intellij {
         'properties',
         "PsiViewer:${psiViewerPluginVersion}"
     ]
+}
+
+patchPluginXml {
+    if (customSinceBuild) {
+        sinceBuild customSinceBuild
+    }
+    if (customUntilBuild) {
+        untilBuild customUntilBuild
+    }
+
+    changeNotes = htmlFixer('src/main/resources/META-INF/change-notes.html')
+    pluginDescription = htmlFixer('src/main/resources/META-INF/description.html')
 }
 
 publishPlugin {

--- a/lang-fluid/src/main/java/com/cedricziel/idea/fluid/codeInsight/template/LiveTemplateFactory.java
+++ b/lang-fluid/src/main/java/com/cedricziel/idea/fluid/codeInsight/template/LiveTemplateFactory.java
@@ -47,4 +47,17 @@ public class LiveTemplateFactory {
 
         return template;
     }
+
+    public static Template createInlinePipeToDebugTemplate(@NotNull PsiElement source) {
+        StringBuilder sb = new StringBuilder();
+        sb
+            .append("{ $EXPR$ -> f:debug() }")
+        ;
+
+        TemplateImpl template = new TemplateImpl("f:debug", sb.toString(), "Fluid");
+        template.setDescription("f:debug the expression result");
+        template.setToReformat(true);
+
+        return template;
+    }
 }

--- a/lang-fluid/src/main/java/com/cedricziel/idea/fluid/codeInsight/template/LiveTemplateFactory.java
+++ b/lang-fluid/src/main/java/com/cedricziel/idea/fluid/codeInsight/template/LiveTemplateFactory.java
@@ -4,6 +4,7 @@ import com.cedricziel.idea.fluid.viewHelpers.model.ViewHelper;
 import com.cedricziel.idea.fluid.viewHelpers.model.ViewHelperArgument;
 import com.intellij.codeInsight.template.Template;
 import com.intellij.codeInsight.template.impl.TemplateImpl;
+import com.intellij.psi.PsiElement;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -18,7 +19,7 @@ public class LiveTemplateFactory {
             int pos = requiredArguments.indexOf(a);
             sb.append(a.name).append(": ").append("$VAR").append(pos).append("$");
 
-            if (requiredArguments.size() > pos + 1){
+            if (requiredArguments.size() > pos + 1) {
                 sb.append(", ");
             }
         });
@@ -26,6 +27,22 @@ public class LiveTemplateFactory {
 
         TemplateImpl template = new TemplateImpl("params", sb.toString(), "Fluid");
         template.setDescription("smart viewhelper parameters completion");
+        template.setToReformat(true);
+
+        return template;
+    }
+
+    public static Template createTagModeForLoopTemplate(@NotNull PsiElement wrap) {
+        StringBuilder sb = new StringBuilder();
+
+        sb
+            .append("<f:for each=\"$EACH$\" as=\"$AS$\">\n")
+            .append("  $END$\n")
+            .append("</f:for>\n")
+        ;
+
+        TemplateImpl template = new TemplateImpl("f:for", sb.toString(), "Fluid");
+        template.setDescription("f:for loop over an expression");
         template.setToReformat(true);
 
         return template;

--- a/lang-fluid/src/main/java/com/cedricziel/idea/fluid/codeInsight/template/postfix/templates/DebugInlinePostfixTemplate.java
+++ b/lang-fluid/src/main/java/com/cedricziel/idea/fluid/codeInsight/template/postfix/templates/DebugInlinePostfixTemplate.java
@@ -1,0 +1,61 @@
+package com.cedricziel.idea.fluid.codeInsight.template.postfix.templates;
+
+import com.cedricziel.idea.fluid.codeInsight.template.LiveTemplateFactory;
+import com.cedricziel.idea.fluid.lang.psi.FluidFieldChain;
+import com.cedricziel.idea.fluid.lang.psi.FluidInlineStatement;
+import com.cedricziel.idea.fluid.lang.psi.FluidTypes;
+import com.cedricziel.idea.fluid.lang.psi.FluidViewHelperExpr;
+import com.intellij.codeInsight.template.Template;
+import com.intellij.codeInsight.template.TemplateManager;
+import com.intellij.codeInsight.template.impl.TextExpression;
+import com.intellij.codeInsight.template.postfix.templates.PostfixTemplate;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.patterns.PlatformPatterns;
+import com.intellij.psi.PsiDocumentManager;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.util.PsiTreeUtil;
+import org.jetbrains.annotations.NotNull;
+
+public class DebugInlinePostfixTemplate extends PostfixTemplate {
+
+    protected DebugInlinePostfixTemplate() {
+        super("f:debug", "Pipes the expression result into a debug statement");
+    }
+
+    @Override
+    public boolean isApplicable(@NotNull PsiElement context, @NotNull Document copyDocument, int newOffset) {
+        return PlatformPatterns
+            .or(
+                PlatformPatterns.psiElement(FluidTypes.IDENTIFIER).withParent(
+                    PlatformPatterns.psiElement(FluidFieldChain.class)
+                ),
+                PlatformPatterns.and(
+                    PlatformPatterns.psiElement().withParent(
+                        FluidViewHelperExpr.class
+                    ),
+                    PlatformPatterns.psiElement(FluidTypes.RIGHT_PARENTH)
+                )
+            )
+            .accepts(context);
+    }
+
+    @Override
+    public void expand(@NotNull PsiElement context, @NotNull Editor editor) {
+        FluidInlineStatement expression = (FluidInlineStatement) PsiTreeUtil.findFirstParent(context, psiElement -> psiElement instanceof FluidInlineStatement);
+        if (expression == null) {
+            return;
+        }
+
+        Template tagTemplate = LiveTemplateFactory.createInlinePipeToDebugTemplate(expression);
+        tagTemplate.addVariable("EXPR", new TextExpression(expression.getInlineChain().getText()), true);
+
+        int textOffset = expression.getTextOffset() + expression.getTextLength();
+        editor.getCaretModel().moveToOffset(textOffset);
+
+        TemplateManager.getInstance(context.getProject()).startTemplate(editor, tagTemplate);
+        PsiDocumentManager.getInstance(context.getProject()).commitDocument(editor.getDocument());
+
+        expression.delete();
+    }
+}

--- a/lang-fluid/src/main/java/com/cedricziel/idea/fluid/codeInsight/template/postfix/templates/FluidPostfixTemplateProvider.java
+++ b/lang-fluid/src/main/java/com/cedricziel/idea/fluid/codeInsight/template/postfix/templates/FluidPostfixTemplateProvider.java
@@ -14,7 +14,8 @@ public class FluidPostfixTemplateProvider implements PostfixTemplateProvider {
     @Override
     public Set<PostfixTemplate> getTemplates() {
         return ContainerUtil.set(
-            new ForEachPostfixTemplate()
+            new ForEachPostfixTemplate(),
+            new DebugInlinePostfixTemplate()
         );
     }
 

--- a/lang-fluid/src/main/java/com/cedricziel/idea/fluid/codeInsight/template/postfix/templates/ForEachPostfixTemplate.java
+++ b/lang-fluid/src/main/java/com/cedricziel/idea/fluid/codeInsight/template/postfix/templates/ForEachPostfixTemplate.java
@@ -1,12 +1,13 @@
 package com.cedricziel.idea.fluid.codeInsight.template.postfix.templates;
 
-import com.cedricziel.idea.fluid.lang.psi.FluidFieldChain;
-import com.cedricziel.idea.fluid.lang.psi.FluidInlineStatement;
-import com.cedricziel.idea.fluid.lang.psi.FluidTypes;
+import com.cedricziel.idea.fluid.codeInsight.template.LiveTemplateFactory;
+import com.cedricziel.idea.fluid.lang.psi.*;
+import com.intellij.codeInsight.template.Template;
+import com.intellij.codeInsight.template.TemplateManager;
+import com.intellij.codeInsight.template.impl.TextExpression;
 import com.intellij.codeInsight.template.postfix.templates.PostfixTemplate;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
-import com.intellij.openapi.editor.EditorModificationUtil;
 import com.intellij.patterns.PlatformPatterns;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiElement;
@@ -21,39 +22,37 @@ public class ForEachPostfixTemplate extends PostfixTemplate {
 
     @Override
     public boolean isApplicable(@NotNull PsiElement context, @NotNull Document copyDocument, int newOffset) {
-        return PlatformPatterns.psiElement(FluidTypes.IDENTIFIER)
-            .withParent(PlatformPatterns.psiElement(FluidFieldChain.class))
+        return PlatformPatterns.or(
+                PlatformPatterns.psiElement(FluidTypes.IDENTIFIER).withParent(
+                    PlatformPatterns.psiElement(FluidFieldChain.class)
+                ),
+                PlatformPatterns.and(
+                    PlatformPatterns.psiElement().withParent(
+                        FluidViewHelperExpr.class
+                    ),
+                    PlatformPatterns.psiElement(FluidTypes.RIGHT_PARENTH)
+                )
+            )
             .accepts(context);
     }
 
     @Override
     public void expand(@NotNull PsiElement context, @NotNull Editor editor) {
-        StringBuilder newText = new StringBuilder();
-        PsiElement parent = context.getParent();
-        PsiElement child = parent.getFirstChild();
-
-        newText.append(child.getText());
-        while (child.getNextSibling() != null) {
-            child = child.getNextSibling();
-
-            newText.append(child.getText());
-        }
-
-        FluidInlineStatement fluidInlineStatement = (FluidInlineStatement) PsiTreeUtil.findFirstParent(context, psiElement -> psiElement instanceof FluidInlineStatement);
-        if (fluidInlineStatement == null) {
+        FluidInlineStatement expression = (FluidInlineStatement) PsiTreeUtil.findFirstParent(context, psiElement -> psiElement instanceof FluidInlineStatement);
+        if (expression == null) {
             return;
         }
 
-        int textOffset = fluidInlineStatement.getTextOffset();
+        Template tagTemplate = LiveTemplateFactory.createTagModeForLoopTemplate(expression);
+        tagTemplate.addVariable("EACH", new TextExpression(expression.getText()), true);
+        tagTemplate.addVariable("AS", new TextExpression("myVar"), true);
+
+        int textOffset = expression.getTextOffset();
         editor.getCaretModel().moveToOffset(textOffset);
-        String foreachStatement = "<f:for each=\"" + fluidInlineStatement.getText() + "\" as=\"\">\n </f:for>";
-        EditorModificationUtil.insertStringAtCaret(editor, foreachStatement);
+
+        TemplateManager.getInstance(context.getProject()).startTemplate(editor, tagTemplate);
         PsiDocumentManager.getInstance(context.getProject()).commitDocument(editor.getDocument());
 
-        fluidInlineStatement.delete();
-
-        editor.getCaretModel().moveToOffset(textOffset + 19 + fluidInlineStatement.getTextLength());
-
-        // CodeStyleManager.getInstance(context.getProject()).reformatText(context.getContainingFile(), textOffset, textOffset + foreachStatement.length());
+        expression.delete();
     }
 }

--- a/lang-fluid/src/main/java/com/cedricziel/idea/fluid/util/FluidUtil.java
+++ b/lang-fluid/src/main/java/com/cedricziel/idea/fluid/util/FluidUtil.java
@@ -1,8 +1,14 @@
 package com.cedricziel.idea.fluid.util;
 
 import com.cedricziel.idea.fluid.extensionPoints.VariableProvider;
+import com.cedricziel.idea.fluid.lang.FluidLanguage;
+import com.cedricziel.idea.fluid.lang.psi.FluidElement;
+import com.cedricziel.idea.fluid.lang.psi.FluidFile;
 import com.cedricziel.idea.fluid.variables.FluidVariable;
+import com.intellij.psi.FileViewProvider;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.util.containers.ContainerUtil;
 import gnu.trove.THashMap;
 import org.jetbrains.annotations.NotNull;
 
@@ -16,5 +22,38 @@ public class FluidUtil {
         }
 
         return variables;
+    }
+
+    public static FluidElement retrieveFluidElementAtPosition(PsiElement psiElement) {
+        FileViewProvider viewProvider = psiElement.getContainingFile().getViewProvider();
+        if (!viewProvider.getLanguages().contains(FluidLanguage.INSTANCE)) {
+            return null;
+        }
+
+        int textOffset = psiElement.getTextOffset();
+        FluidFile psi = (FluidFile) viewProvider.getPsi(FluidLanguage.INSTANCE);
+
+        PsiElement elementAt = psi.findElementAt(textOffset);
+        if (elementAt == null) {
+            return null;
+        }
+
+        return (FluidElement) elementAt;
+    }
+
+    public static FluidElement retrieveFluidElementAtPosition(PsiFile psiFile, int startOffset) {
+        FileViewProvider viewProvider = psiFile.getViewProvider();
+        if (!viewProvider.getLanguages().contains(FluidLanguage.INSTANCE)) {
+            return null;
+        }
+
+        FluidFile psi = (FluidFile) viewProvider.getPsi(FluidLanguage.INSTANCE);
+
+        PsiElement elementAt = psi.findElementAt(startOffset);
+        if (elementAt == null) {
+            return null;
+        }
+
+        return (FluidElement) elementAt;
     }
 }

--- a/lang-fluid/src/main/java/icons/FluidIcons.java
+++ b/lang-fluid/src/main/java/icons/FluidIcons.java
@@ -5,8 +5,8 @@ import com.intellij.openapi.util.IconLoader;
 import javax.swing.*;
 
 public class FluidIcons {
-    public static final Icon FILE = IconLoader.getIcon("icons/icon-typo3.png");
-    public static final Icon TYPO3 = IconLoader.getIcon("icons/icon-typo3.png");
-    public static final Icon VIEW_HELPER = IconLoader.getIcon("icons/icon-typo3.png");
-    public static final Icon VARIABLE = IconLoader.getIcon("icons/icon-typo3.png");
+    public static final Icon FILE = IconLoader.getIcon("/icons/icon-typo3.png");
+    public static final Icon TYPO3 = IconLoader.getIcon("/icons/icon-typo3.png");
+    public static final Icon VIEW_HELPER = IconLoader.getIcon("/icons/icon-typo3.png");
+    public static final Icon VARIABLE = IconLoader.getIcon("/icons/icon-typo3.png");
 }

--- a/lang-fluid/src/main/resources/META-INF/change-notes.html
+++ b/lang-fluid/src/main/resources/META-INF/change-notes.html
@@ -1,0 +1,5 @@
+<html><ul>
+<li>2c53518 [Fluid] Fix Icon path reference (Cedric Ziel)</li>
+<li>96962a1 Add .debug postfix completion (Cedric Ziel)</li>
+<li>3e7ddb5 Convert ForEachPostfix completion to LiveTemplate (Cedric Ziel)</li>
+<li>b9ec6e3 Amend READMEs (Cedric Ziel)</li></ul></html>

--- a/lang-fluid/src/main/resources/META-INF/description.html
+++ b/lang-fluid/src/main/resources/META-INF/description.html
@@ -1,0 +1,15 @@
+<html>
+<strong>TYPO3 Fluid plugin for IntelliJ based IDEs</strong>
+<br/>
+<br/>
+<a href="https://github.com/cedricziel/idea-php-typo3-plugin">GitHub</a> |
+<a href="https://github.com/cedricziel/idea-php-typo3-plugin/issues">Bug Tracker</a> |
+<a href="https://www.patreon.com/cedricziel">Donate (Patreon)</a>
+<a href="https://www.paypal.me/ziel">Donate (Paypal)</a>
+<br/>
+<br/>
+
+This plugin is in an early draft stage. The project aims to provide
+a fully OpenSource plugin for the Fluid Template Language.
+
+</html>

--- a/lang-fluid/src/main/resources/postfixTemplates/DebugInlinePostfixTemplate/after.fluid.html
+++ b/lang-fluid/src/main/resources/postfixTemplates/DebugInlinePostfixTemplate/after.fluid.html
@@ -1,0 +1,1 @@
+{var -> my:mutation() -> f:debug()}

--- a/lang-fluid/src/main/resources/postfixTemplates/DebugInlinePostfixTemplate/before.fluid.html
+++ b/lang-fluid/src/main/resources/postfixTemplates/DebugInlinePostfixTemplate/before.fluid.html
@@ -1,0 +1,1 @@
+{var -> <spot>my:mutation()</spot>$key}

--- a/lang-fluid/src/main/resources/postfixTemplates/DebugInlinePostfixTemplate/description.html
+++ b/lang-fluid/src/main/resources/postfixTemplates/DebugInlinePostfixTemplate/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Debugs an expression result with f:debug
+</body>
+</html>

--- a/lang-fluid/src/test/java/com/cedricziel/idea/fluid/codeInsight/template/postfix/templates/AbtractTemplateTest.java
+++ b/lang-fluid/src/test/java/com/cedricziel/idea/fluid/codeInsight/template/postfix/templates/AbtractTemplateTest.java
@@ -1,0 +1,61 @@
+package com.cedricziel.idea.fluid.codeInsight.template.postfix.templates;
+
+import com.intellij.codeInsight.completion.CompletionAutoPopupTestCase;
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.codeInsight.lookup.impl.LookupImpl;
+import com.intellij.codeInsight.template.impl.LiveTemplateCompletionContributor;
+import com.intellij.codeInsight.template.postfix.completion.PostfixTemplateLookupElement;
+import com.intellij.codeInsight.template.postfix.settings.PostfixTemplatesSettings;
+import com.intellij.testFramework.EdtTestUtil;
+import com.intellij.util.containers.ContainerUtil;
+
+abstract public class AbtractTemplateTest extends CompletionAutoPopupTestCase {
+    @Override
+    public void setUp() {
+
+        super.setUp();
+
+        LiveTemplateCompletionContributor.setShowTemplatesInTests(false, myFixture.getTestRootDisposable());
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        try {
+            PostfixTemplatesSettings settings = PostfixTemplatesSettings.getInstance();
+            assertNotNull(settings);
+            settings.setProviderToDisabledTemplates(ContainerUtil.newHashMap());
+            settings.setPostfixTemplatesEnabled(true);
+            settings.setTemplatesCompletionEnabled(true);
+        } finally {
+            super.tearDown();
+        }
+    }
+
+    protected void doCompleteTest(String textToType, char c) {
+        configureByFile();
+        type(textToType);
+        assertNotNull(getLookup());
+        myFixture.type(c);
+        checkResultByFile();
+    }
+
+    private void configureByFile() {
+        EdtTestUtil.runInEdtAndWait(() -> myFixture.configureByFile(getTestName(true) + ".fluid"));
+    }
+
+    private void checkResultByFile() {
+        myFixture.checkResultByFile(getTestName(true) + "_after.fluid", true);
+    }
+
+    protected void testLiveTemplateIsAvailable(String completionChar, String templateContent) {
+        myFixture.configureByText("foo.fluid", templateContent);
+        type(completionChar);
+        LookupImpl lookup = getLookup();
+        assertNotNull(lookup);
+
+        LookupElement item = lookup.getCurrentItem();
+        assertNotNull(item);
+        assertInstanceOf(item, PostfixTemplateLookupElement.class);
+        assertInstanceOf(((PostfixTemplateLookupElement) item).getPostfixTemplate(), ForEachPostfixTemplate.class);
+    }
+}

--- a/lang-fluid/src/test/java/com/cedricziel/idea/fluid/codeInsight/template/postfix/templates/AbtractTemplateTest.java
+++ b/lang-fluid/src/test/java/com/cedricziel/idea/fluid/codeInsight/template/postfix/templates/AbtractTemplateTest.java
@@ -47,7 +47,7 @@ abstract public class AbtractTemplateTest extends CompletionAutoPopupTestCase {
         myFixture.checkResultByFile(getTestName(true) + "_after.fluid", true);
     }
 
-    protected void testLiveTemplateIsAvailable(String completionChar, String templateContent) {
+    protected void testLiveTemplateIsAvailable(String completionChar, String templateContent, Class templateClass) {
         myFixture.configureByText("foo.fluid", templateContent);
         type(completionChar);
         LookupImpl lookup = getLookup();
@@ -56,6 +56,6 @@ abstract public class AbtractTemplateTest extends CompletionAutoPopupTestCase {
         LookupElement item = lookup.getCurrentItem();
         assertNotNull(item);
         assertInstanceOf(item, PostfixTemplateLookupElement.class);
-        assertInstanceOf(((PostfixTemplateLookupElement) item).getPostfixTemplate(), ForEachPostfixTemplate.class);
+        assertInstanceOf(((PostfixTemplateLookupElement) item).getPostfixTemplate(), templateClass);
     }
 }

--- a/lang-fluid/src/test/java/com/cedricziel/idea/fluid/codeInsight/template/postfix/templates/DebugInlinePostfixTemplateTest.java
+++ b/lang-fluid/src/test/java/com/cedricziel/idea/fluid/codeInsight/template/postfix/templates/DebugInlinePostfixTemplateTest.java
@@ -2,7 +2,7 @@ package com.cedricziel.idea.fluid.codeInsight.template.postfix.templates;
 
 import com.intellij.codeInsight.template.impl.LiveTemplateCompletionContributor;
 
-public class ForEachPostfixTemplateTest extends AbtractTemplateTest {
+public class DebugInlinePostfixTemplateTest extends AbtractTemplateTest {
 
     @Override
     protected String getTestDataPath() {
@@ -12,18 +12,18 @@ public class ForEachPostfixTemplateTest extends AbtractTemplateTest {
     public void testCanExpandLiveTemplateOnVariable() {
         LiveTemplateCompletionContributor.setShowTemplatesInTests(true, myFixture.getTestRootDisposable());
 
-        testLiveTemplateIsAvailable(".for", "{foo.bar<caret>}", ForEachPostfixTemplate.class);
+        testLiveTemplateIsAvailable(".deb", "{foo.bar<caret>}", DebugInlinePostfixTemplate.class);
     }
 
     public void testCanExpandLiveTemplateOnChainedExpression() {
         LiveTemplateCompletionContributor.setShowTemplatesInTests(true, myFixture.getTestRootDisposable());
 
-        testLiveTemplateIsAvailable(".for", "{foo.bar -> my:view.helper()<caret>}", ForEachPostfixTemplate.class);
+        testLiveTemplateIsAvailable(".deb", "{foo.bar -> my:view.helper()<caret>}", DebugInlinePostfixTemplate.class);
     }
 
-    public void testForeachTemplate() {
+    public void testDebugTemplate() {
         LiveTemplateCompletionContributor.setShowTemplatesInTests(true, myFixture.getTestRootDisposable());
 
-        doCompleteTest(".for", '\n');
+        doCompleteTest(".deb", '\n');
     }
 }

--- a/lang-fluid/src/test/java/com/cedricziel/idea/fluid/codeInsight/template/postfix/templates/ForEachPostfixTemplateTest.java
+++ b/lang-fluid/src/test/java/com/cedricziel/idea/fluid/codeInsight/template/postfix/templates/ForEachPostfixTemplateTest.java
@@ -1,0 +1,29 @@
+package com.cedricziel.idea.fluid.codeInsight.template.postfix.templates;
+
+import com.intellij.codeInsight.template.impl.LiveTemplateCompletionContributor;
+
+public class ForEachPostfixTemplateTest extends AbtractTemplateTest {
+
+    @Override
+    protected String getTestDataPath() {
+        return "testData/com/cedricziel/idea/fluid/codeInsight/template/postfix";
+    }
+
+    public void testCanExpandLiveTemplateOnVariable() {
+        LiveTemplateCompletionContributor.setShowTemplatesInTests(true, myFixture.getTestRootDisposable());
+
+        testLiveTemplateIsAvailable(".f", "{foo.bar<caret>}");
+    }
+
+    public void testCanExpandLiveTemplateOnChainedExpression() {
+        LiveTemplateCompletionContributor.setShowTemplatesInTests(true, myFixture.getTestRootDisposable());
+
+        testLiveTemplateIsAvailable(".f", "{foo.bar -> my:view.helper()<caret>}");
+    }
+
+    public void testForeachTemplate() {
+        LiveTemplateCompletionContributor.setShowTemplatesInTests(true, myFixture.getTestRootDisposable());
+
+        doCompleteTest(".f", '\n');
+    }
+}

--- a/lang-fluid/testData/com/cedricziel/idea/fluid/codeInsight/template/postfix/debugTemplate.fluid
+++ b/lang-fluid/testData/com/cedricziel/idea/fluid/codeInsight/template/postfix/debugTemplate.fluid
@@ -1,0 +1,1 @@
+{ myVar<caret> }

--- a/lang-fluid/testData/com/cedricziel/idea/fluid/codeInsight/template/postfix/debugTemplate_after.fluid
+++ b/lang-fluid/testData/com/cedricziel/idea/fluid/codeInsight/template/postfix/debugTemplate_after.fluid
@@ -1,0 +1,1 @@
+{ myVar -> f:debug() }

--- a/lang-fluid/testData/com/cedricziel/idea/fluid/codeInsight/template/postfix/foreachTemplate.fluid
+++ b/lang-fluid/testData/com/cedricziel/idea/fluid/codeInsight/template/postfix/foreachTemplate.fluid
@@ -1,0 +1,1 @@
+{ foo.bar<caret> }

--- a/lang-fluid/testData/com/cedricziel/idea/fluid/codeInsight/template/postfix/foreachTemplate_after.fluid
+++ b/lang-fluid/testData/com/cedricziel/idea/fluid/codeInsight/template/postfix/foreachTemplate_after.fluid
@@ -1,0 +1,4 @@
+<f:for each="{ foo.bar }" as="myVar">
+
+</f:for>
+

--- a/lang-typoscript/build.gradle
+++ b/lang-typoscript/build.gradle
@@ -1,6 +1,7 @@
 import org.jetbrains.grammarkit.tasks.GenerateLexer
 import org.jetbrains.grammarkit.tasks.GenerateParser
 
+def htmlFixer = { htmlFile -> file(htmlFile).text.replace('<html>', '').replace('</html>', '') }
 def genRoot = file('gen')
 sourceSets {
     main {
@@ -31,6 +32,19 @@ intellij {
         "PsiViewer:${psiViewerPluginVersion}",
     ]
 }
+
+patchPluginXml {
+    if (customSinceBuild) {
+        sinceBuild customSinceBuild
+    }
+    if (customUntilBuild) {
+        untilBuild customUntilBuild
+    }
+
+    changeNotes = htmlFixer('src/main/resources/META-INF/change-notes.html')
+    pluginDescription = htmlFixer('src/main/resources/META-INF/description.html')
+}
+
 
 publishPlugin {
     channels 'nightly'

--- a/lang-typoscript/src/main/resources/META-INF/change-notes.html
+++ b/lang-typoscript/src/main/resources/META-INF/change-notes.html
@@ -1,0 +1,5 @@
+<html><ul>
+<li>2c53518 [Fluid] Fix Icon path reference (Cedric Ziel)</li>
+<li>96962a1 Add .debug postfix completion (Cedric Ziel)</li>
+<li>3e7ddb5 Convert ForEachPostfix completion to LiveTemplate (Cedric Ziel)</li>
+<li>b9ec6e3 Amend READMEs (Cedric Ziel)</li></ul></html>

--- a/lang-typoscript/src/main/resources/META-INF/description.html
+++ b/lang-typoscript/src/main/resources/META-INF/description.html
@@ -1,0 +1,15 @@
+<html>
+<strong>TypoScript Language support</strong>
+<br/>
+<br/>
+<a href="https://github.com/cedricziel/idea-php-typo3-plugin">GitHub</a> |
+<a href="https://github.com/cedricziel/idea-php-typo3-plugin/issues">Bug Tracker</a> |
+<a href="https://www.patreon.com/cedricziel">Donate (Patreon)</a>
+<a href="https://www.paypal.me/ziel">Donate (Paypal)</a>
+<br/>
+<br/>
+
+This plugin is in an early draft stage. The project aims to provide
+a fully OpenSource plugin for the TypoScript configuration language.
+
+</html>

--- a/prepare-release.sh
+++ b/prepare-release.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+echo "<html><ul>" > change-notes.html
+git log `git describe --tags --abbrev=0`..HEAD --oneline --pretty=format:"<li>%h %s (%an)</li>" >> change-notes.html
+echo "</ul></html>" >> change-notes.html
+
+cp change-notes.html lang-fluid/src/main/resources/META-INF/
+cp change-notes.html lang-typoscript/src/main/resources/META-INF/
+cp change-notes.html typo3-cms/src/main/resources/META-INF/
+
+rm change-notes.html

--- a/typo3-cms/build.gradle
+++ b/typo3-cms/build.gradle
@@ -1,3 +1,5 @@
+def htmlFixer = { htmlFile -> file(htmlFile).text.replace('<html>', '').replace('</html>', '') }
+
 intellij {
     version ideaVersion
     pluginName 'TYPO3 CMS Plugin'
@@ -11,4 +13,16 @@ intellij {
         project(':lang-fluid'),
         project(':lang-typoscript'),
     ]
+}
+
+patchPluginXml {
+    if (customSinceBuild) {
+        sinceBuild customSinceBuild
+    }
+    if (customUntilBuild) {
+        untilBuild customUntilBuild
+    }
+
+    changeNotes = htmlFixer('src/main/resources/META-INF/change-notes.html')
+    pluginDescription = htmlFixer('src/main/resources/META-INF/description.html')
 }

--- a/typo3-cms/src/main/resources/META-INF/change-notes.html
+++ b/typo3-cms/src/main/resources/META-INF/change-notes.html
@@ -1,0 +1,5 @@
+<html><ul>
+<li>2c53518 [Fluid] Fix Icon path reference (Cedric Ziel)</li>
+<li>96962a1 Add .debug postfix completion (Cedric Ziel)</li>
+<li>3e7ddb5 Convert ForEachPostfix completion to LiveTemplate (Cedric Ziel)</li>
+<li>b9ec6e3 Amend READMEs (Cedric Ziel)</li></ul></html>

--- a/typo3-cms/src/main/resources/META-INF/description.html
+++ b/typo3-cms/src/main/resources/META-INF/description.html
@@ -1,0 +1,32 @@
+<html>
+<strong>TYPO3 CMS Plugin for IntelliJ based IDEs</strong>
+<br/>
+<br/>
+<a href="https://github.com/cedricziel/idea-php-typo3-plugin">GitHub</a> |
+<a href="https://github.com/cedricziel/idea-php-typo3-plugin/issues">Bug Tracker</a> |
+<a href="https://www.patreon.com/cedricziel">Donate (Patreon)</a>
+<a href="https://www.paypal.me/ziel">Donate (Paypal)</a>
+<br/>
+<br/>
+This plugin aims to support development of websites with the TYPO3 CMS Framework.
+<br/>
+Features:
+<ul>
+<li>TypeProvider for `GeneralUtility::makeInstance`</li>
+<li>TypeProvider for `GeneralUtility::makeInstanceService`</li>
+<li>TypeProvider for `ObjectManager::get`</li>
+<li>TypeProvider for `$GLOBALS['TYPO3_DB']`, `$GLOBALS['TSFE']` and `$GLOBALS['BE_USER']`</li>
+<li>CompletionContributor for `UriBuilder::buildUriFromRoute` and `BackendUtility::getAjaxUrl`</li>
+<li>CompletionContributor for `IconFactory::getIcon`</li>
+<li>Annotator for both valid and invalid route references to make them distinguishable from normal strings</li>
+<li>Annotator for both valid and invalid icon references to core-defined icons</li>
+<li>Annotator for both valid and invalid icon references to core-defined icons</li>
+<li>Inspection: Extbase `@inject` property injection + QuickFix</li>
+<li>**Experimental:** Generate Fluid Styled Content Element (please report bugs!)</li>
+<li>Generate ViewHelpers</li>
+<li>Generate ActionControllers</li>
+<li>Create TYPO3 Projects from sketch</li>
+<li>classic layout (through [https://github.com/TYPO3/TYPO3.CMS](https://github.com/TYPO3/TYPO3.CMS))</li>
+<li>composer based project through [https://github.com/TYPO3/TYPO3.CMS.BaseDistribution](https://github.com/TYPO3/TYPO3.CMS.BaseDistribution)</li>
+</ul>
+</html>


### PR DESCRIPTION
Changes the string template to a live template.

* adds a changelog tool
* fixes an error with 2018.1 where icons are not correctly resolved.