### PR TITLE
[Fluid] Lex multi-char namespace imports correctly

### DIFF
--- a/lang-fluid/src/main/grammars/FluidParser.bnf
+++ b/lang-fluid/src/main/grammars/FluidParser.bnf
@@ -88,7 +88,7 @@ fake Statement ::=
 
 template_comment ::= "<!--/*" COMMENT_CONTENT? "*/-->"
 
-NamespaceStatement ::= '{' 'namespace' NAMESPACE_ALIAS '=' ViewHelperNamespace '}' {
+NamespaceStatement ::= '{' 'namespace' NamespaceAlias '=' ViewHelperNamespace '}' {
   pin=2
   methods = [
     getAlias
@@ -97,6 +97,7 @@ NamespaceStatement ::= '{' 'namespace' NAMESPACE_ALIAS '=' ViewHelperNamespace '
   mixin="com.cedricziel.idea.fluid.lang.psi.impl.FluidNamespaceStatementMixin"
   implements = "com.cedricziel.idea.fluid.lang.psi.FluidAccessibleNamespaceStatement"
 }
+private NamespaceAlias ::= NAMESPACE_ALIAS
 ViewHelperNamespace ::= NS ('\' NS)*
 
 string_literal ::= SINGLE_QUOTED_STRING | DOUBLE_QUOTED_STRING {

--- a/lang-fluid/src/test/java/com/cedricziel/idea/fluid/namespaces/InlineNSNamespaceProviderTest.java
+++ b/lang-fluid/src/test/java/com/cedricziel/idea/fluid/namespaces/InlineNSNamespaceProviderTest.java
@@ -10,8 +10,13 @@ import java.util.List;
 
 public class InlineNSNamespaceProviderTest extends AbstractFluidTest {
     public void testThatInlineNamespacesAreProvided() {
+        assertNamespaceDeclared("{namespace v=FluidTYPO3\\Vhs\\ViewHelpers}", "v", "FluidTYPO3/Vhs/ViewHelpers");
+        assertNamespaceDeclared("{namespace app=My\\App\\ViewHelpers}", "app", "My/App/ViewHelpers");
+    }
+
+    private void assertNamespaceDeclared(String nsNode, String prefix, String namespace) {
         PsiFile psiFile = myFixture.configureByText("foo.fluid", "<html xmlns:f=\"http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers\" xmlns:formvh=\"http://typo3.org/ns/TYPO3/CMS/Form/ViewHelpers\" data-namespace-typo3-fluid=\"true\">\n" +
-            "{namespace v=FluidTYPO3\\Vhs\\ViewHelpers}\n"+
+            nsNode + "\n" +
             "<formvh:renderRenderable renderable=\"{element}\">\n" +
             "\t<f:render partial=\"Field/Field\" arguments=\"{element: element}\" contentAs=\"elementContent\">\n" +
             "\t\t<f:form.textfield\n" +
@@ -31,6 +36,6 @@ public class InlineNSNamespaceProviderTest extends AbstractFluidTest {
 
         List<FluidNamespace> namespaces = FluidUtil.getFluidNamespaces(elementAtCaret);
 
-        assertContainsNamespace(namespaces, "v", "FluidTYPO3/Vhs/ViewHelpers");
+        assertContainsNamespace(namespaces, prefix, namespace);
     }
 }

--- a/lang-fluid/src/test/java/com/cedricziel/idea/fluid/viewHelpers/PhpViewHelpersProviderTest.java
+++ b/lang-fluid/src/test/java/com/cedricziel/idea/fluid/viewHelpers/PhpViewHelpersProviderTest.java
@@ -11,14 +11,19 @@ public class PhpViewHelpersProviderTest extends AbstractFluidTest {
     public void testViewHelpersCanBeProvidedViaPHP() {
         myFixture.copyFileToProject("classes.php");
 
+        configureNamespaceAndTriggerComplete("{namespace a=App\\ViewHelpers}");
+        assertCurrentCompletionContains("a:foo");
+
+        configureNamespaceAndTriggerComplete("{namespace app=App\\ViewHelpers}");
+        assertCurrentCompletionContains("app:foo");
+    }
+
+    private void configureNamespaceAndTriggerComplete(String namespaceNode) {
         myFixture.configureByText(
             "foo.fluid",
-            "{namespace a=App\\ViewHelpers}\n" +
-                "{<caret>}"
+            namespaceNode + "\n" + "{<caret>}"
         );
 
         myFixture.completeBasic();
-
-        assertCurrentCompletionContains("a:foo");
     }
 }


### PR DESCRIPTION
Up until now, a namespace alias with multiple chars (`app`) were not
possible.

This changeset compliments the lexer to accept it, with a new parsing
state.

```
{namespace app=My\Project\ViewHelpers}
```