### PR TITLE
[T3CMS] Introduce project settings

### DIFF
--- a/typo3-cms/src/main/java/com/cedricziel/idea/typo3/IdeHelper.java
+++ b/typo3-cms/src/main/java/com/cedricziel/idea/typo3/IdeHelper.java
@@ -1,0 +1,43 @@
+package com.cedricziel.idea.typo3;
+
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationType;
+import com.intellij.notification.Notifications;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+
+public class IdeHelper {
+    /**
+     * @author Daniel Espendiller <daniel@espendiller.net>
+     */
+    public static void notifyEnableMessage(final Project project) {
+        Notification notification = new Notification(
+            "TYPO3 CMS Plugin",
+            "TYPO3 CMS Plugin",
+            "Enable the TYPO3 CMS Plugin <a href=\"enable\">with auto configuration now</a>, open <a href=\"config\">Project Settings</a> or <a href=\"dismiss\">dismiss</a> further messages",
+            NotificationType.INFORMATION,
+            (notification1, event) -> {
+                // handle html click events
+                if ("config".equals(event.getDescription())) {
+                    // open settings dialog and show panel
+                    TYPO3CMSProjectSettings.showSettings(project);
+                } else if ("enable".equals(event.getDescription())) {
+                    enablePluginAndConfigure(project);
+
+                    Notifications.Bus.notify(new Notification("TYPO3 CMS Plugin", "TYPO3 CMS Plugin", "Plugin enabled", NotificationType.INFORMATION), project);
+                } else if ("dismiss".equals(event.getDescription())) {
+                    // user doesn't want to show notification again
+                    TYPO3CMSProjectSettings.getInstance(project).dismissEnableNotification = true;
+                }
+
+                notification1.expire();
+            }
+        );
+
+        Notifications.Bus.notify(notification, project);
+    }
+
+    private static void enablePluginAndConfigure(@NotNull Project project) {
+        TYPO3CMSProjectSettings.getInstance(project).pluginEnabled = true;
+    }
+}

--- a/typo3-cms/src/main/java/com/cedricziel/idea/typo3/TYPO3CMSProjectSettings.java
+++ b/typo3-cms/src/main/java/com/cedricziel/idea/typo3/TYPO3CMSProjectSettings.java
@@ -1,0 +1,48 @@
+package com.cedricziel.idea.typo3;
+
+import com.intellij.ide.actions.ShowSettingsUtilImpl;
+import com.intellij.openapi.components.PersistentStateComponent;
+import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.components.State;
+import com.intellij.openapi.components.Storage;
+import com.intellij.openapi.project.Project;
+import com.intellij.util.xmlb.XmlSerializerUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@State(
+    name = "typo3cmsproject",
+    storages = {
+        @Storage("/typo3-cms.xml")
+    }
+)
+public class TYPO3CMSProjectSettings implements PersistentStateComponent<TYPO3CMSProjectSettings> {
+
+    public boolean pluginEnabled;
+    public boolean dismissEnableNotification;
+
+    public TYPO3CMSProjectSettings() {
+        this.pluginEnabled = false;
+        this.dismissEnableNotification = false;
+    }
+
+    public static TYPO3CMSProjectSettings getInstance(@NotNull Project project) {
+
+        return ServiceManager.getService(project, TYPO3CMSProjectSettings.class);
+    }
+
+    public static void showSettings(@NotNull Project project) {
+        ShowSettingsUtilImpl.showSettingsDialog(project, "TYPO3CMS.SettingsForm", null);
+    }
+
+    @Nullable
+    @Override
+    public TYPO3CMSProjectSettings getState() {
+        return this;
+    }
+
+    @Override
+    public void loadState(@NotNull TYPO3CMSProjectSettings state) {
+        XmlSerializerUtil.copyBean(state, this);
+    }
+}

--- a/typo3-cms/src/main/java/com/cedricziel/idea/typo3/TYPO3CMSSettings.java
+++ b/typo3-cms/src/main/java/com/cedricziel/idea/typo3/TYPO3CMSSettings.java
@@ -19,7 +19,7 @@ public class TYPO3CMSSettings implements PersistentStateComponent<Element> {
      */
     private String version;
 
-    public static TYPO3CMSSettings getInstance(Project project) {
+    public static TYPO3CMSSettings getInstance(@NotNull Project project) {
         return ServiceManager.getService(project, TYPO3CMSSettings.class);
     }
 
@@ -64,7 +64,7 @@ public class TYPO3CMSSettings implements PersistentStateComponent<Element> {
      * Settings keys.
      */
     public enum KEY {
-        ROOT("TYPO3CMSSettings"),
+        ROOT("TYPO3CMSSettingsForm"),
         VERSION("version");
 
         private final String key;

--- a/typo3-cms/src/main/java/com/cedricziel/idea/typo3/configuration/TYPO3CMSSettingsForm.form
+++ b/typo3-cms/src/main/java/com/cedricziel/idea/typo3/configuration/TYPO3CMSSettingsForm.form
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.cedricziel.idea.typo3.configuration.TYPO3CMSSettingsForm">
+  <grid id="27dc6" binding="panel" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+    <margin top="0" left="0" bottom="0" right="0"/>
+    <constraints>
+      <xy x="20" y="20" width="500" height="400"/>
+    </constraints>
+    <properties/>
+    <border type="none"/>
+    <children>
+      <vspacer id="ba971">
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </vspacer>
+      <component id="d8d1e" class="javax.swing.JCheckBox" binding="enablePlugin">
+        <constraints>
+          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Enable Plugin (change may require restart)"/>
+        </properties>
+      </component>
+    </children>
+  </grid>
+</form>

--- a/typo3-cms/src/main/java/com/cedricziel/idea/typo3/configuration/TYPO3CMSSettingsForm.java
+++ b/typo3-cms/src/main/java/com/cedricziel/idea/typo3/configuration/TYPO3CMSSettingsForm.java
@@ -1,0 +1,59 @@
+package com.cedricziel.idea.typo3.configuration;
+
+import com.cedricziel.idea.typo3.TYPO3CMSProjectSettings;
+import com.intellij.openapi.options.Configurable;
+import com.intellij.openapi.options.ConfigurationException;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+
+public class TYPO3CMSSettingsForm implements Configurable {
+    @NotNull
+    private final Project project;
+
+    private JCheckBox enablePlugin;
+    private JPanel panel;
+
+    public TYPO3CMSSettingsForm(@NotNull Project project) {
+        this.project = project;
+    }
+
+    @Nls(capitalization = Nls.Capitalization.Title)
+    @Override
+    public String getDisplayName() {
+        return "TYPO3 CMS Plugin";
+    }
+
+    @Override
+    public void reset() {
+        updateUIFromSettings();
+    }
+
+    @Nullable
+    @Override
+    public JComponent createComponent() {
+        return panel;
+    }
+
+    @Override
+    public boolean isModified() {
+
+        return !enablePlugin.isSelected() == getSettings().pluginEnabled;
+    }
+
+    @Override
+    public void apply() throws ConfigurationException {
+        getSettings().pluginEnabled = enablePlugin.isSelected();
+    }
+
+    public TYPO3CMSProjectSettings getSettings() {
+        return TYPO3CMSProjectSettings.getInstance(project);
+    }
+
+    private void updateUIFromSettings() {
+        enablePlugin.setSelected(getSettings().pluginEnabled);
+    }
+}

--- a/typo3-cms/src/main/resources/META-INF/plugin.xml
+++ b/typo3-cms/src/main/resources/META-INF/plugin.xml
@@ -153,6 +153,13 @@ It is a great inspiration for possible solutions and parts of the code.</p>
     <extensions defaultExtensionNs="com.intellij">
 
         <projectService serviceImplementation="com.cedricziel.idea.typo3.TYPO3CMSSettings"/>
+        <projectService serviceImplementation="com.cedricziel.idea.typo3.TYPO3CMSProjectSettings"/>
+
+        <projectConfigurable displayName="TYPO3 CMS"
+                             id="TYPO3CMS.SettingsForm"
+                             parentId="reference.webide.settings.project.settings.php"
+                             nonDefaultProject="true"
+                             instance="com.cedricziel.idea.typo3.configuration.TYPO3CMSSettingsForm"/>
 
         <directoryProjectGenerator implementation="com.cedricziel.idea.typo3.projectTemplate.TYPO3CMSClassicLayoutDirectoryProjectGenerator"/>
         <projectTemplatesFactory implementation="com.cedricziel.idea.typo3.projectTemplate.TYPO3CMSProjectTemplatesFactory"/>


### PR DESCRIPTION
To resolve some issues and enable customization, this change introduces
project settings and most importantly a way to enable / disable
the plugin functionality for a project.

The TYPO3CMSProjectComponent tries to detect a TYPO3 CMS project and
proposes to enable itself.

Followups should include enabling / disabling inspections and other
features based on this setting which should slightly improve performance
in projects that don't need the functionality.