### PR TITLE
[T3CMS] Add Inspection for invalid internal_type TCA option on v9 and up

### DIFF
--- a/typo3-cms/src/main/java/com/cedricziel/idea/typo3/tca/codeInspection/v10/InternalTypeFileInspection.java
+++ b/typo3-cms/src/main/java/com/cedricziel/idea/typo3/tca/codeInspection/v10/InternalTypeFileInspection.java
@@ -1,0 +1,86 @@
+package com.cedricziel.idea.typo3.tca.codeInspection.v10;
+
+import com.cedricziel.idea.typo3.TYPO3CMSProjectSettings;
+import com.cedricziel.idea.typo3.psi.PhpElementsUtil;
+import com.cedricziel.idea.typo3.util.TCAUtil;
+import com.cedricziel.idea.typo3.util.TYPO3Utility;
+import com.intellij.codeInsight.daemon.GroupNames;
+import com.intellij.codeInspection.ProblemHighlightType;
+import com.intellij.codeInspection.ProblemsHolder;
+import com.intellij.psi.PsiElementVisitor;
+import com.jetbrains.php.lang.inspections.PhpInspection;
+import com.jetbrains.php.lang.psi.elements.PhpPsiElement;
+import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
+import com.jetbrains.php.lang.psi.visitors.PhpElementVisitor;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
+
+import static com.cedricziel.idea.typo3.psi.PhpElementsUtil.extractArrayIndexFromValue;
+import static com.cedricziel.idea.typo3.util.TCAUtil.insideTCAColumnDefinition;
+
+public class InternalTypeFileInspection extends PhpInspection {
+
+    @Nls
+    @NotNull
+    @Override
+    public String getGroupDisplayName() {
+        return GroupNames.BUGS_GROUP_NAME;
+    }
+
+    @NotNull
+    public String getDisplayName() {
+        return "Invalid Internal type";
+    }
+
+    @NotNull
+    public String getShortName() {
+        return "InternalTypeFileInspection";
+    }
+
+    @NotNull
+    @Override
+    public PsiElementVisitor buildVisitor(@NotNull ProblemsHolder problemsHolder, boolean b) {
+        if (!TYPO3CMSProjectSettings.getInstance(problemsHolder.getProject()).pluginEnabled) {
+            return new PhpElementVisitor() {
+            };
+        }
+
+        // the internal type was deprecated on 9 and dropped on 10
+        if (TYPO3Utility.compareMajorMinorVersion(problemsHolder.getProject(), "9.0") < 0) {
+            return new PhpElementVisitor() {
+            };
+        }
+
+        return new PhpElementVisitor() {
+            @Override
+            public void visitPhpElement(PhpPsiElement element) {
+
+                boolean isArrayStringValue = PhpElementsUtil.isStringArrayValue().accepts(element);
+                if (!isArrayStringValue || !insideTCAColumnDefinition(element)) {
+                    return;
+                }
+
+
+                String arrayIndex = extractArrayIndexFromValue(element);
+                if (arrayIndex != null && arrayIndex.equals("internal_type")) {
+                    if (element instanceof StringLiteralExpression) {
+                        String internalType = ((StringLiteralExpression) element).getContents();
+
+                        if (!internalType.equals("file_reference") && !internalType.equals("file")) {
+                            return;
+                        }
+
+                        // the internal type was deprecated on 9 and dropped on 10
+                        if (TYPO3Utility.compareMajorMinorVersion(problemsHolder.getProject(), "10.0") < 0) {
+                            problemsHolder.registerProblem(element, String.format("Internal type '%s' is deprecated, will be removed with v10.0", internalType), ProblemHighlightType.LIKE_DEPRECATED);
+
+                            return;
+                        }
+
+                        problemsHolder.registerProblem(element, String.format("Internal type '%s' was removed prior to v10.0", internalType), ProblemHighlightType.GENERIC_ERROR_OR_WARNING);
+                    }
+                }
+            }
+        };
+    }
+}

--- a/typo3-cms/src/main/resources/META-INF/plugin.xml
+++ b/typo3-cms/src/main/resources/META-INF/plugin.xml
@@ -244,6 +244,12 @@ It is a great inspiration for possible solutions and parts of the code.</p>
                          implementationClass="com.cedricziel.idea.typo3.tca.codeInspection.InvalidQuantityInspection"/>
 
         <localInspection language="PHP" groupPath="TYPO3 CMS"
+                         shortName="InternalTypeFileInspection" displayName="Invalid Internal type"
+                         groupName="TCA"
+                         enabledByDefault="true" level="WARNING"
+                         implementationClass="com.cedricziel.idea.typo3.tca.codeInspection.v10.InternalTypeFileInspection"/>
+
+        <localInspection language="PHP" groupPath="TYPO3 CMS"
                          shortName="LegacyClassesForIDEInspection" displayName="Legacy class used"
                          groupName="Code Migration"
                          enabledByDefault="true" level="WARNING"

--- a/typo3-cms/src/test/java/com/cedricziel/idea/typo3/tca/codeInspection/v10/InternalTypeFileInspectionTest.java
+++ b/typo3-cms/src/test/java/com/cedricziel/idea/typo3/tca/codeInspection/v10/InternalTypeFileInspectionTest.java
@@ -1,0 +1,58 @@
+package com.cedricziel.idea.typo3.tca.codeInspection.v10;
+
+import com.cedricziel.idea.typo3.AbstractTestCase;
+import com.cedricziel.idea.typo3.tca.codeInspection.InvalidQuantityInspection;
+import com.intellij.openapi.vfs.VirtualFile;
+
+public class InternalTypeFileInspectionTest extends AbstractTestCase {
+    @Override
+    protected String getTestDataPath() {
+        return super.getTestDataPath() + "/tca/codeInspection/v10";
+    }
+
+    public void testInvalidInternalTypeIsNotDisplayedWhenPluginIsDisabled() {
+        disablePlugin();
+
+        myFixture.enableInspections(InternalTypeFileInspection.class);
+
+        myFixture.addFileToProject("foo/ext_emconf.php", "");
+
+        VirtualFile virtualFile = myFixture.copyFileToProject("invalid_internal_type_disabled.php", "foo/Configuration/TCA/tx_news_domain_model_link.php");
+
+        myFixture.configureFromExistingVirtualFile(virtualFile);
+        myFixture.checkHighlighting();
+    }
+
+    public void testInvalidInternalTypeIsNotDisplayedOnv8() {
+        myFixture.enableInspections(InternalTypeFileInspection.class);
+
+        myFixture.addFileToProject("foo/ext_emconf.php", "");
+
+        VirtualFile virtualFile = myFixture.copyFileToProject("invalid_internal_type_v8.php", "foo/Configuration/TCA/tx_news_domain_model_link.php");
+
+        myFixture.configureFromExistingVirtualFile(virtualFile);
+        myFixture.checkHighlighting();
+    }
+
+    public void testInvalidInternalTypeIsDisplayedOnv9() {
+        myFixture.enableInspections(InternalTypeFileInspection.class);
+
+        myFixture.addFileToProject("foo/ext_emconf.php", "");
+
+        VirtualFile virtualFile = myFixture.copyFileToProject("invalid_internal_type_v9.php", "foo/Configuration/TCA/tx_news_domain_model_link.php");
+
+        myFixture.configureFromExistingVirtualFile(virtualFile);
+        myFixture.checkHighlighting();
+    }
+
+    public void testInvalidInternalTypeIsHighlightedOnv10() {
+        myFixture.enableInspections(InternalTypeFileInspection.class);
+
+        myFixture.addFileToProject("foo/ext_emconf.php", "");
+
+        VirtualFile virtualFile = myFixture.copyFileToProject("invalid_internal_type_v10.php", "foo/Configuration/TCA/tx_news_domain_model_link.php");
+
+        myFixture.configureFromExistingVirtualFile(virtualFile);
+        myFixture.checkHighlighting();
+    }
+}

--- a/typo3-cms/testData/com/cedricziel/idea/typo3/tca/codeInspection/v10/invalid_internal_type_disabled.php
+++ b/typo3-cms/testData/com/cedricziel/idea/typo3/tca/codeInspection/v10/invalid_internal_type_disabled.php
@@ -1,0 +1,27 @@
+<?php
+defined('TYPO3_MODE') or die();
+
+define('TYPO3_branch', '9.5');
+
+$ll = 'LLL:EXT:news/Resources/Private/Language/locallang_db.xlf:';
+
+return [
+    'ctrl' => [
+    ],
+    'interface' => [
+    ],
+    'columns' => [
+        'description' => [
+            'exclude' => true,
+            'label' => $ll . 'tx_news_domain_model_link.description',
+            'config' => [
+                'type' => 'group',
+                'internal_type' => 'file',
+                'rows' => 5,
+                'behaviour' => [
+                    'allowLanguageSynchronization' => true,
+                ],
+            ]
+        ],
+    ]
+];

--- a/typo3-cms/testData/com/cedricziel/idea/typo3/tca/codeInspection/v10/invalid_internal_type_v10.php
+++ b/typo3-cms/testData/com/cedricziel/idea/typo3/tca/codeInspection/v10/invalid_internal_type_v10.php
@@ -1,0 +1,27 @@
+<?php
+defined('TYPO3_MODE') or die();
+
+define('TYPO3_branch', '10.0');
+
+$ll = 'LLL:EXT:news/Resources/Private/Language/locallang_db.xlf:';
+
+return [
+    'ctrl' => [
+    ],
+    'interface' => [
+    ],
+    'columns' => [
+        'description' => [
+            'exclude' => true,
+            'label' => $ll . 'tx_news_domain_model_link.description',
+            'config' => [
+                'type' => 'group',
+                'internal_type' => <warning descr="Internal type 'file_reference' was removed prior to v10.0">'file_reference'</warning>,
+                'rows' => 5,
+                'behaviour' => [
+                    'allowLanguageSynchronization' => true,
+                ],
+            ]
+        ],
+    ]
+];

--- a/typo3-cms/testData/com/cedricziel/idea/typo3/tca/codeInspection/v10/invalid_internal_type_v8.php
+++ b/typo3-cms/testData/com/cedricziel/idea/typo3/tca/codeInspection/v10/invalid_internal_type_v8.php
@@ -1,0 +1,27 @@
+<?php
+defined('TYPO3_MODE') or die();
+
+define('TYPO3_branch', '8.7');
+
+$ll = 'LLL:EXT:news/Resources/Private/Language/locallang_db.xlf:';
+
+return [
+    'ctrl' => [
+    ],
+    'interface' => [
+    ],
+    'columns' => [
+        'description' => [
+            'exclude' => true,
+            'label' => $ll . 'tx_news_domain_model_link.description',
+            'config' => [
+                'type' => 'group',
+                'internal_type' => 'file',
+                'rows' => 5,
+                'behaviour' => [
+                    'allowLanguageSynchronization' => true,
+                ],
+            ]
+        ],
+    ]
+];

--- a/typo3-cms/testData/com/cedricziel/idea/typo3/tca/codeInspection/v10/invalid_internal_type_v9.php
+++ b/typo3-cms/testData/com/cedricziel/idea/typo3/tca/codeInspection/v10/invalid_internal_type_v9.php
@@ -1,0 +1,27 @@
+<?php
+defined('TYPO3_MODE') or die();
+
+define('TYPO3_branch', '9.5');
+
+$ll = 'LLL:EXT:news/Resources/Private/Language/locallang_db.xlf:';
+
+return [
+    'ctrl' => [
+    ],
+    'interface' => [
+    ],
+    'columns' => [
+        'description' => [
+            'exclude' => true,
+            'label' => $ll . 'tx_news_domain_model_link.description',
+            'config' => [
+                'type' => 'group',
+                'internal_type' => <warning descr="Internal type 'file_reference' is deprecated, will be removed with v10.0">'file_reference'</warning>,
+                'rows' => 5,
+                'behaviour' => [
+                    'allowLanguageSynchronization' => true,
+                ],
+            ]
+        ],
+    ]
+];


### PR DESCRIPTION
The TCA option `internal_type` will have the options `file` and `file_reference` deprecated in v9 and removed in v10.