### PR TITLE
Rework legacy inspections

### DIFF
--- a/typo3-cms/src/main/java/com/cedricziel/idea/typo3/codeInspection/ExtbasePropertyInjectionInspection.java
+++ b/typo3-cms/src/main/java/com/cedricziel/idea/typo3/codeInspection/ExtbasePropertyInjectionInspection.java
@@ -1,18 +1,15 @@
 package com.cedricziel.idea.typo3.codeInspection;
 
-import com.cedricziel.idea.typo3.TYPO3CMSProjectSettings;
 import com.cedricziel.idea.typo3.codeInspection.quickfix.CreateInjectorQuickFix;
 import com.intellij.codeInsight.daemon.GroupNames;
 import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.psi.PsiElementVisitor;
 import com.jetbrains.php.lang.documentation.phpdoc.psi.tags.PhpDocTag;
-import com.jetbrains.php.lang.inspections.PhpInspection;
-import com.jetbrains.php.lang.psi.elements.PhpPsiElement;
 import com.jetbrains.php.lang.psi.visitors.PhpElementVisitor;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 
-public class ExtbasePropertyInjectionInspection extends PhpInspection {
+public class ExtbasePropertyInjectionInspection extends PluginEnabledPhpInspection {
     @Nls
     @NotNull
     @Override
@@ -32,21 +29,15 @@ public class ExtbasePropertyInjectionInspection extends PhpInspection {
 
     @NotNull
     @Override
-    public PsiElementVisitor buildVisitor(@NotNull ProblemsHolder problemsHolder, boolean b) {
-        if (!TYPO3CMSProjectSettings.getInstance(problemsHolder.getProject()).pluginEnabled) {
-            return new PhpElementVisitor() {
-            };
-        }
-
+    public PsiElementVisitor buildRealVisitor(@NotNull ProblemsHolder problemsHolder, boolean b) {
         return new PhpElementVisitor() {
             @Override
-            public void visitPhpElement(PhpPsiElement element) {
-                if (element instanceof PhpDocTag) {
-                    PhpDocTag tag = (PhpDocTag) element;
-                    if ("@inject".equals(tag.getName())) {
-                        problemsHolder.registerProblem(element, "Extbase property injection", new CreateInjectorQuickFix(tag));
-                    }
+            public void visitPhpDocTag(PhpDocTag tag) {
+                if ("@inject".equals(tag.getName())) {
+                    problemsHolder.registerProblem(tag, "Extbase property injection", new CreateInjectorQuickFix(tag));
                 }
+
+                super.visitPhpDocTag(tag);
             }
         };
     }

--- a/typo3-cms/src/main/java/com/cedricziel/idea/typo3/codeInspection/LegacyClassesForIDEInspection.java
+++ b/typo3-cms/src/main/java/com/cedricziel/idea/typo3/codeInspection/LegacyClassesForIDEInspection.java
@@ -1,20 +1,18 @@
 package com.cedricziel.idea.typo3.codeInspection;
 
-import com.cedricziel.idea.typo3.TYPO3CMSProjectSettings;
 import com.cedricziel.idea.typo3.codeInspection.quickfix.LegacyClassesForIdeQuickFix;
 import com.cedricziel.idea.typo3.index.php.LegacyClassesForIDEIndex;
 import com.intellij.codeInsight.daemon.GroupNames;
 import com.intellij.codeInspection.ProblemHighlightType;
 import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.psi.PsiElementVisitor;
-import com.jetbrains.php.lang.inspections.PhpInspection;
 import com.jetbrains.php.lang.psi.elements.ClassConstantReference;
 import com.jetbrains.php.lang.psi.elements.ClassReference;
 import com.jetbrains.php.lang.psi.visitors.PhpElementVisitor;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 
-public class LegacyClassesForIDEInspection extends PhpInspection {
+public class LegacyClassesForIDEInspection extends PluginEnabledPhpInspection {
     @Nls
     @NotNull
     @Override
@@ -37,12 +35,7 @@ public class LegacyClassesForIDEInspection extends PhpInspection {
 
     @NotNull
     @Override
-    public PsiElementVisitor buildVisitor(@NotNull ProblemsHolder problemsHolder, boolean b) {
-        if (!TYPO3CMSProjectSettings.getInstance(problemsHolder.getProject()).pluginEnabled) {
-            return new PhpElementVisitor() {
-            };
-        }
-
+    public PsiElementVisitor buildRealVisitor(@NotNull ProblemsHolder problemsHolder, boolean b) {
         return new PhpElementVisitor() {
             @Override
             public void visitPhpClassReference(ClassReference classReference) {

--- a/typo3-cms/src/main/java/com/cedricziel/idea/typo3/codeInspection/MissingColumnTypeInspection.java
+++ b/typo3-cms/src/main/java/com/cedricziel/idea/typo3/codeInspection/MissingColumnTypeInspection.java
@@ -1,12 +1,10 @@
 package com.cedricziel.idea.typo3.codeInspection;
 
-import com.cedricziel.idea.typo3.TYPO3CMSProjectSettings;
 import com.cedricziel.idea.typo3.psi.PhpElementsUtil;
 import com.cedricziel.idea.typo3.util.TCAUtil;
 import com.intellij.codeInsight.daemon.GroupNames;
 import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.psi.PsiElementVisitor;
-import com.jetbrains.php.lang.inspections.PhpInspection;
 import com.jetbrains.php.lang.psi.elements.PhpPsiElement;
 import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
 import com.jetbrains.php.lang.psi.visitors.PhpElementVisitor;
@@ -16,7 +14,7 @@ import org.jetbrains.annotations.NotNull;
 import static com.cedricziel.idea.typo3.psi.PhpElementsUtil.extractArrayIndexFromValue;
 import static com.cedricziel.idea.typo3.util.TCAUtil.insideTCAColumnDefinition;
 
-public class MissingColumnTypeInspection extends PhpInspection {
+public class MissingColumnTypeInspection extends PluginEnabledPhpInspection {
     @Nls
     @NotNull
     @Override
@@ -36,12 +34,7 @@ public class MissingColumnTypeInspection extends PhpInspection {
 
     @NotNull
     @Override
-    public PsiElementVisitor buildVisitor(@NotNull ProblemsHolder problemsHolder, boolean b) {
-        if (!TYPO3CMSProjectSettings.getInstance(problemsHolder.getProject()).pluginEnabled) {
-            return new PhpElementVisitor() {
-            };
-        }
-
+    public PsiElementVisitor buildRealVisitor(@NotNull ProblemsHolder problemsHolder, boolean b) {
         return new PhpElementVisitor() {
             @Override
             public void visitPhpElement(PhpPsiElement element) {

--- a/typo3-cms/src/main/java/com/cedricziel/idea/typo3/codeInspection/MissingRenderTypeInspection.java
+++ b/typo3-cms/src/main/java/com/cedricziel/idea/typo3/codeInspection/MissingRenderTypeInspection.java
@@ -1,12 +1,10 @@
 package com.cedricziel.idea.typo3.codeInspection;
 
-import com.cedricziel.idea.typo3.TYPO3CMSProjectSettings;
 import com.cedricziel.idea.typo3.psi.PhpElementsUtil;
 import com.cedricziel.idea.typo3.util.TCAUtil;
 import com.intellij.codeInsight.daemon.GroupNames;
 import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.psi.PsiElementVisitor;
-import com.jetbrains.php.lang.inspections.PhpInspection;
 import com.jetbrains.php.lang.psi.elements.PhpPsiElement;
 import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
 import com.jetbrains.php.lang.psi.visitors.PhpElementVisitor;
@@ -16,7 +14,7 @@ import org.jetbrains.annotations.NotNull;
 import static com.cedricziel.idea.typo3.psi.PhpElementsUtil.extractArrayIndexFromValue;
 import static com.cedricziel.idea.typo3.util.TCAUtil.insideTCAColumnDefinition;
 
-public class MissingRenderTypeInspection extends PhpInspection {
+public class MissingRenderTypeInspection extends PluginEnabledPhpInspection {
     @Nls
     @NotNull
     @Override
@@ -36,12 +34,7 @@ public class MissingRenderTypeInspection extends PhpInspection {
 
     @NotNull
     @Override
-    public PsiElementVisitor buildVisitor(@NotNull ProblemsHolder problemsHolder, boolean b) {
-        if (!TYPO3CMSProjectSettings.getInstance(problemsHolder.getProject()).pluginEnabled) {
-            return new PhpElementVisitor() {
-            };
-        }
-
+    public PsiElementVisitor buildRealVisitor(@NotNull ProblemsHolder problemsHolder, boolean b) {
         return new PhpElementVisitor() {
             @Override
             public void visitPhpElement(PhpPsiElement element) {

--- a/typo3-cms/src/main/java/com/cedricziel/idea/typo3/codeInspection/MissingTableInspection.java
+++ b/typo3-cms/src/main/java/com/cedricziel/idea/typo3/codeInspection/MissingTableInspection.java
@@ -1,12 +1,10 @@
 package com.cedricziel.idea.typo3.codeInspection;
 
-import com.cedricziel.idea.typo3.TYPO3CMSProjectSettings;
 import com.cedricziel.idea.typo3.psi.PhpElementsUtil;
 import com.cedricziel.idea.typo3.util.TableUtil;
 import com.intellij.codeInsight.daemon.GroupNames;
 import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.psi.PsiElementVisitor;
-import com.jetbrains.php.lang.inspections.PhpInspection;
 import com.jetbrains.php.lang.psi.elements.PhpPsiElement;
 import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
 import com.jetbrains.php.lang.psi.visitors.PhpElementVisitor;
@@ -17,7 +15,7 @@ import static com.cedricziel.idea.typo3.psi.PhpElementsUtil.extractArrayIndexFro
 import static com.cedricziel.idea.typo3.util.TCAUtil.arrayIndexIsTCATableNameField;
 import static com.cedricziel.idea.typo3.util.TCAUtil.insideTCAColumnDefinition;
 
-public class MissingTableInspection extends PhpInspection {
+public class MissingTableInspection extends PluginEnabledPhpInspection {
     @Nls
     @NotNull
     @Override
@@ -37,12 +35,7 @@ public class MissingTableInspection extends PhpInspection {
 
     @NotNull
     @Override
-    public PsiElementVisitor buildVisitor(@NotNull ProblemsHolder problemsHolder, boolean b) {
-        if (!TYPO3CMSProjectSettings.getInstance(problemsHolder.getProject()).pluginEnabled) {
-            return new PhpElementVisitor() {
-            };
-        }
-
+    public PsiElementVisitor buildRealVisitor(@NotNull ProblemsHolder problemsHolder, boolean b) {
         return new PhpElementVisitor() {
             @Override
             public void visitPhpElement(PhpPsiElement element) {

--- a/typo3-cms/src/main/java/com/cedricziel/idea/typo3/codeInspection/PluginEnabledPhpInspection.java
+++ b/typo3-cms/src/main/java/com/cedricziel/idea/typo3/codeInspection/PluginEnabledPhpInspection.java
@@ -1,0 +1,24 @@
+package com.cedricziel.idea.typo3.codeInspection;
+
+import com.cedricziel.idea.typo3.TYPO3CMSProjectSettings;
+import com.intellij.codeInspection.ProblemsHolder;
+import com.intellij.psi.PsiElementVisitor;
+import com.jetbrains.php.lang.inspections.PhpInspection;
+import com.jetbrains.php.lang.psi.visitors.PhpElementVisitor;
+import org.jetbrains.annotations.NotNull;
+
+public abstract class PluginEnabledPhpInspection extends PhpInspection {
+    @NotNull
+    @Override
+    public PsiElementVisitor buildVisitor(@NotNull ProblemsHolder problemsHolder, boolean b) {
+        if (!TYPO3CMSProjectSettings.getInstance(problemsHolder.getProject()).pluginEnabled) {
+            return new PhpElementVisitor() {
+            };
+        }
+
+        return buildRealVisitor(problemsHolder, b);
+    }
+
+    @NotNull
+    public abstract PsiElementVisitor buildRealVisitor(@NotNull ProblemsHolder problemsHolder, boolean b);
+}

--- a/typo3-cms/src/main/java/com/cedricziel/idea/typo3/extensionScanner/codeInspection/ClassConstantMatcherInspection.java
+++ b/typo3-cms/src/main/java/com/cedricziel/idea/typo3/extensionScanner/codeInspection/ClassConstantMatcherInspection.java
@@ -1,29 +1,16 @@
 package com.cedricziel.idea.typo3.extensionScanner.codeInspection;
 
+import com.cedricziel.idea.typo3.codeInspection.PluginEnabledPhpInspection;
+import com.cedricziel.idea.typo3.util.DeprecationUtility;
 import com.intellij.codeInsight.daemon.GroupNames;
 import com.intellij.codeInspection.ProblemsHolder;
-import com.intellij.patterns.PlatformPatterns;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
-import com.intellij.psi.PsiFile;
-import com.intellij.psi.search.FilenameIndex;
-import com.intellij.psi.search.GlobalSearchScope;
-import com.intellij.psi.util.PsiTreeUtil;
-import com.jetbrains.php.lang.inspections.PhpInspection;
-import com.jetbrains.php.lang.parser.PhpElementTypes;
 import com.jetbrains.php.lang.psi.elements.ClassConstantReference;
-import com.jetbrains.php.lang.psi.elements.PhpPsiElement;
-import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
 import com.jetbrains.php.lang.psi.visitors.PhpElementVisitor;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-public class ClassConstantMatcherInspection extends PhpInspection {
+public class ClassConstantMatcherInspection extends PluginEnabledPhpInspection {
     @Nls
     @NotNull
     @Override
@@ -38,45 +25,18 @@ public class ClassConstantMatcherInspection extends PhpInspection {
 
     @NotNull
     @Override
-    public PsiElementVisitor buildVisitor(@NotNull ProblemsHolder problemsHolder, boolean b) {
+    public PsiElementVisitor buildRealVisitor(@NotNull ProblemsHolder problemsHolder, boolean b) {
         return new PhpElementVisitor() {
+
             @Override
-            public void visitPhpElement(PhpPsiElement element) {
-
-                if (!PlatformPatterns.psiElement(PhpElementTypes.CLASS_CONSTANT_REFERENCE).accepts(element)) {
-                    return;
+            public void visitPhpClassConstantReference(ClassConstantReference constantReference) {
+                if (DeprecationUtility.isDeprecated(problemsHolder.getProject(), constantReference)) {
+                    problemsHolder.registerProblem(constantReference, "Deprecated class constant");
                 }
 
-                Set<String> constants = getDeprecatedClassConstants(element);
-                ClassConstantReference classConstantReference = (ClassConstantReference) element;
-                if (constants.contains(classConstantReference.getText())) {
-                    problemsHolder.registerProblem(element, "Deprecated class constant");
-                }
+                super.visitPhpClassConstantReference(constantReference);
             }
         };
     }
 
-    private Set<String> getDeprecatedClassConstants(PhpPsiElement element) {
-        Set<PsiElement> elements = new HashSet<>();
-        PsiFile[] classConstantMatcherFiles = FilenameIndex.getFilesByName(element.getProject(), "ClassConstantMatcher.php", GlobalSearchScope.allScope(element.getProject()));
-        for (PsiFile file : classConstantMatcherFiles) {
-
-            Collections.addAll(
-                    elements,
-                    PsiTreeUtil.collectElements(file, el -> PlatformPatterns
-                            .psiElement(StringLiteralExpression.class)
-                            .withParent(
-                                    PlatformPatterns.psiElement(PhpElementTypes.ARRAY_KEY)
-                                            .withAncestor(
-                                                    4,
-                                                    PlatformPatterns.psiElement(PhpElementTypes.RETURN)
-                                            )
-                            )
-                            .accepts(el)
-                    )
-            );
-        }
-
-        return elements.stream().map(stringLiteral -> ((StringLiteralExpression)stringLiteral).getContents()).collect(Collectors.toSet());
-    }
 }

--- a/typo3-cms/src/main/java/com/cedricziel/idea/typo3/extensionScanner/codeInspection/ClassNameMatcherInspection.java
+++ b/typo3-cms/src/main/java/com/cedricziel/idea/typo3/extensionScanner/codeInspection/ClassNameMatcherInspection.java
@@ -1,29 +1,19 @@
 package com.cedricziel.idea.typo3.extensionScanner.codeInspection;
 
+import com.cedricziel.idea.typo3.codeInspection.PluginEnabledPhpInspection;
 import com.intellij.codeInsight.daemon.GroupNames;
 import com.intellij.codeInspection.ProblemsHolder;
-import com.intellij.patterns.PlatformPatterns;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
-import com.intellij.psi.PsiFile;
-import com.intellij.psi.search.FilenameIndex;
-import com.intellij.psi.search.GlobalSearchScope;
-import com.intellij.psi.util.PsiTreeUtil;
-import com.jetbrains.php.lang.inspections.PhpInspection;
-import com.jetbrains.php.lang.parser.PhpElementTypes;
 import com.jetbrains.php.lang.psi.elements.ClassReference;
-import com.jetbrains.php.lang.psi.elements.PhpPsiElement;
-import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
 import com.jetbrains.php.lang.psi.visitors.PhpElementVisitor;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
 
-public class ClassNameMatcherInspection extends PhpInspection {
+import static com.cedricziel.idea.typo3.util.DeprecationUtility.getDeprecatedClassNames;
+
+public class ClassNameMatcherInspection extends PluginEnabledPhpInspection {
     @Nls
     @NotNull
     @Override
@@ -38,47 +28,18 @@ public class ClassNameMatcherInspection extends PhpInspection {
 
     @NotNull
     @Override
-    public PsiElementVisitor buildVisitor(@NotNull ProblemsHolder problemsHolder, boolean b) {
+    public PsiElementVisitor buildRealVisitor(@NotNull ProblemsHolder problemsHolder, boolean b) {
         return new PhpElementVisitor() {
+
             @Override
-            public void visitPhpElement(PhpPsiElement element) {
-
-                if (!PlatformPatterns.psiElement(PhpElementTypes.CLASS_REFERENCE).accepts(element)) {
-                    return;
+            public void visitPhpClassReference(ClassReference classReference) {
+                Set<String> deprecatedClassNames = getDeprecatedClassNames(classReference.getProject());
+                if (deprecatedClassNames.contains(classReference.getFQN())) {
+                    problemsHolder.registerProblem(classReference, "Class scheduled for removal in upcoming TYPO3 version, consider using an alternative");
                 }
 
-                Set<String> constants = getDeprecatedClasses(element);
-                ClassReference classReference = (ClassReference) element;
-                if (constants.contains(classReference.getFQN())) {
-                    problemsHolder.registerProblem(element, "Class removed with TYPO3 9, consider using an alternative");
-                }
+                super.visitPhpClassReference(classReference);
             }
         };
-    }
-
-    private Set<String> getDeprecatedClasses(PhpPsiElement element) {
-        Set<PsiElement> elements = new HashSet<>();
-        PsiFile[] classNameMatcherFiles = FilenameIndex.getFilesByName(element.getProject(), "ClassNameMatcher.php", GlobalSearchScope.allScope(element.getProject()));
-        for (PsiFile file : classNameMatcherFiles) {
-
-            Collections.addAll(
-                    elements,
-                    PsiTreeUtil.collectElements(file, el -> PlatformPatterns
-                            .psiElement(StringLiteralExpression.class)
-                            .withParent(
-                                    PlatformPatterns.psiElement(PhpElementTypes.ARRAY_KEY)
-                                            .withAncestor(
-                                                    4,
-                                                    PlatformPatterns.psiElement(PhpElementTypes.RETURN)
-                                            )
-                            )
-                            .accepts(el)
-                    )
-            );
-        }
-
-        return elements.stream()
-                .map(stringLiteral -> "\\" + ((StringLiteralExpression)stringLiteral).getContents())
-                .collect(Collectors.toSet());
     }
 }

--- a/typo3-cms/src/main/java/com/cedricziel/idea/typo3/extensionScanner/codeInspection/ConstantMatcherInspection.java
+++ b/typo3-cms/src/main/java/com/cedricziel/idea/typo3/extensionScanner/codeInspection/ConstantMatcherInspection.java
@@ -1,5 +1,6 @@
 package com.cedricziel.idea.typo3.extensionScanner.codeInspection;
 
+import com.cedricziel.idea.typo3.codeInspection.PluginEnabledPhpInspection;
 import com.intellij.codeInsight.daemon.GroupNames;
 import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.patterns.PlatformPatterns;
@@ -9,7 +10,6 @@ import com.intellij.psi.PsiFile;
 import com.intellij.psi.search.FilenameIndex;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.util.PsiTreeUtil;
-import com.jetbrains.php.lang.inspections.PhpInspection;
 import com.jetbrains.php.lang.parser.PhpElementTypes;
 import com.jetbrains.php.lang.psi.elements.ConstantReference;
 import com.jetbrains.php.lang.psi.elements.PhpPsiElement;
@@ -23,7 +23,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class ConstantMatcherInspection extends PhpInspection {
+public class ConstantMatcherInspection extends PluginEnabledPhpInspection {
     @Nls
     @NotNull
     @Override
@@ -38,7 +38,7 @@ public class ConstantMatcherInspection extends PhpInspection {
 
     @NotNull
     @Override
-    public PsiElementVisitor buildVisitor(@NotNull ProblemsHolder problemsHolder, boolean b) {
+    public PsiElementVisitor buildRealVisitor(@NotNull ProblemsHolder problemsHolder, boolean b) {
         return new PhpElementVisitor() {
             @Override
             public void visitPhpElement(PhpPsiElement element) {
@@ -62,23 +62,23 @@ public class ConstantMatcherInspection extends PhpInspection {
         for (PsiFile file : constantMatcherFiles) {
 
             Collections.addAll(
-                    elements,
-                    PsiTreeUtil.collectElements(file, el -> PlatformPatterns
-                            .psiElement(StringLiteralExpression.class)
-                            .withParent(
-                                    PlatformPatterns.psiElement(PhpElementTypes.ARRAY_KEY)
-                                            .withAncestor(
-                                                    4,
-                                                    PlatformPatterns.psiElement(PhpElementTypes.RETURN)
-                                            )
+                elements,
+                PsiTreeUtil.collectElements(file, el -> PlatformPatterns
+                    .psiElement(StringLiteralExpression.class)
+                    .withParent(
+                        PlatformPatterns.psiElement(PhpElementTypes.ARRAY_KEY)
+                            .withAncestor(
+                                4,
+                                PlatformPatterns.psiElement(PhpElementTypes.RETURN)
                             )
-                            .accepts(el)
                     )
+                    .accepts(el)
+                )
             );
         }
 
         return elements.stream()
-                .map(stringLiteral -> "\\" + ((StringLiteralExpression)stringLiteral).getContents())
-                .collect(Collectors.toSet());
+            .map(stringLiteral -> "\\" + ((StringLiteralExpression) stringLiteral).getContents())
+            .collect(Collectors.toSet());
     }
 }

--- a/typo3-cms/src/main/java/com/cedricziel/idea/typo3/extensionScanner/codeInspection/ConstantMatcherInspection.java
+++ b/typo3-cms/src/main/java/com/cedricziel/idea/typo3/extensionScanner/codeInspection/ConstantMatcherInspection.java
@@ -1,26 +1,14 @@
 package com.cedricziel.idea.typo3.extensionScanner.codeInspection;
 
 import com.cedricziel.idea.typo3.codeInspection.PluginEnabledPhpInspection;
+import com.cedricziel.idea.typo3.util.DeprecationUtility;
 import com.intellij.codeInsight.daemon.GroupNames;
 import com.intellij.codeInspection.ProblemsHolder;
-import com.intellij.patterns.PlatformPatterns;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
-import com.intellij.psi.PsiFile;
-import com.intellij.psi.search.FilenameIndex;
-import com.intellij.psi.search.GlobalSearchScope;
-import com.intellij.psi.util.PsiTreeUtil;
-import com.jetbrains.php.lang.parser.PhpElementTypes;
 import com.jetbrains.php.lang.psi.elements.ConstantReference;
-import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
 import com.jetbrains.php.lang.psi.visitors.PhpElementVisitor;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 public class ConstantMatcherInspection extends PluginEnabledPhpInspection {
     @Nls
@@ -41,39 +29,12 @@ public class ConstantMatcherInspection extends PluginEnabledPhpInspection {
         return new PhpElementVisitor() {
             @Override
             public void visitPhpConstantReference(ConstantReference reference) {
-                Set<String> constants = getRemovedConstantsFQNs(reference);
-                if (constants.contains(reference.getFQN())) {
-                    problemsHolder.registerProblem(reference, "Constant removed with TYPO3 9, consider using an alternative");
+                if (DeprecationUtility.isDeprecated(problemsHolder.getProject(), reference)) {
+                    problemsHolder.registerProblem(reference, "Constant scheduled for removal in upcoming TYPO3 version, consider using an alternative");
                 }
 
                 super.visitPhpConstantReference(reference);
             }
         };
-    }
-
-    private Set<String> getRemovedConstantsFQNs(ConstantReference element) {
-        Set<PsiElement> elements = new HashSet<>();
-        PsiFile[] constantMatcherFiles = FilenameIndex.getFilesByName(element.getProject(), "ConstantMatcher.php", GlobalSearchScope.allScope(element.getProject()));
-        for (PsiFile file : constantMatcherFiles) {
-
-            Collections.addAll(
-                elements,
-                PsiTreeUtil.collectElements(file, el -> PlatformPatterns
-                    .psiElement(StringLiteralExpression.class)
-                    .withParent(
-                        PlatformPatterns.psiElement(PhpElementTypes.ARRAY_KEY)
-                            .withAncestor(
-                                4,
-                                PlatformPatterns.psiElement(PhpElementTypes.RETURN)
-                            )
-                    )
-                    .accepts(el)
-                )
-            );
-        }
-
-        return elements.stream()
-            .map(stringLiteral -> "\\" + ((StringLiteralExpression) stringLiteral).getContents())
-            .collect(Collectors.toSet());
     }
 }

--- a/typo3-cms/src/main/java/com/cedricziel/idea/typo3/extensionScanner/codeInspection/ConstantMatcherInspection.java
+++ b/typo3-cms/src/main/java/com/cedricziel/idea/typo3/extensionScanner/codeInspection/ConstantMatcherInspection.java
@@ -12,7 +12,6 @@ import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.jetbrains.php.lang.parser.PhpElementTypes;
 import com.jetbrains.php.lang.psi.elements.ConstantReference;
-import com.jetbrains.php.lang.psi.elements.PhpPsiElement;
 import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
 import com.jetbrains.php.lang.psi.visitors.PhpElementVisitor;
 import org.jetbrains.annotations.Nls;
@@ -41,17 +40,13 @@ public class ConstantMatcherInspection extends PluginEnabledPhpInspection {
     public PsiElementVisitor buildRealVisitor(@NotNull ProblemsHolder problemsHolder, boolean b) {
         return new PhpElementVisitor() {
             @Override
-            public void visitPhpElement(PhpPsiElement element) {
-
-                if (!PlatformPatterns.psiElement(PhpElementTypes.CONSTANT_REF).accepts(element)) {
-                    return;
+            public void visitPhpConstantReference(ConstantReference reference) {
+                Set<String> constants = getRemovedConstantsFQNs(reference);
+                if (constants.contains(reference.getFQN())) {
+                    problemsHolder.registerProblem(reference, "Constant removed with TYPO3 9, consider using an alternative");
                 }
 
-                ConstantReference constantReference = (ConstantReference) element;
-                Set<String> constants = getRemovedConstantsFQNs(constantReference);
-                if (constants.contains(constantReference.getFQN())) {
-                    problemsHolder.registerProblem(element, "Constant removed with TYPO3 9, consider using an alternative");
-                }
+                super.visitPhpConstantReference(reference);
             }
         };
     }

--- a/typo3-cms/src/main/java/com/cedricziel/idea/typo3/extensionScanner/codeInspection/FunctionCallMatcherInspection.java
+++ b/typo3-cms/src/main/java/com/cedricziel/idea/typo3/extensionScanner/codeInspection/FunctionCallMatcherInspection.java
@@ -1,5 +1,6 @@
 package com.cedricziel.idea.typo3.extensionScanner.codeInspection;
 
+import com.cedricziel.idea.typo3.codeInspection.PluginEnabledPhpInspection;
 import com.intellij.codeInsight.daemon.GroupNames;
 import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.patterns.PlatformPatterns;
@@ -9,7 +10,6 @@ import com.intellij.psi.PsiFile;
 import com.intellij.psi.search.FilenameIndex;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.util.PsiTreeUtil;
-import com.jetbrains.php.lang.inspections.PhpInspection;
 import com.jetbrains.php.lang.parser.PhpElementTypes;
 import com.jetbrains.php.lang.psi.elements.FunctionReference;
 import com.jetbrains.php.lang.psi.elements.PhpPsiElement;
@@ -23,7 +23,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class FunctionCallMatcherInspection extends PhpInspection {
+public class FunctionCallMatcherInspection extends PluginEnabledPhpInspection {
     @Nls
     @NotNull
     @Override
@@ -38,7 +38,7 @@ public class FunctionCallMatcherInspection extends PhpInspection {
 
     @NotNull
     @Override
-    public PsiElementVisitor buildVisitor(@NotNull ProblemsHolder problemsHolder, boolean b) {
+    public PsiElementVisitor buildRealVisitor(@NotNull ProblemsHolder problemsHolder, boolean b) {
         return new PhpElementVisitor() {
             @Override
             public void visitPhpElement(PhpPsiElement element) {
@@ -62,23 +62,23 @@ public class FunctionCallMatcherInspection extends PhpInspection {
         for (PsiFile file : constantMatcherFiles) {
 
             Collections.addAll(
-                    elements,
-                    PsiTreeUtil.collectElements(file, el -> PlatformPatterns
-                            .psiElement(StringLiteralExpression.class)
-                            .withParent(
-                                    PlatformPatterns.psiElement(PhpElementTypes.ARRAY_KEY)
-                                            .withAncestor(
-                                                    4,
-                                                    PlatformPatterns.psiElement(PhpElementTypes.RETURN)
-                                            )
+                elements,
+                PsiTreeUtil.collectElements(file, el -> PlatformPatterns
+                    .psiElement(StringLiteralExpression.class)
+                    .withParent(
+                        PlatformPatterns.psiElement(PhpElementTypes.ARRAY_KEY)
+                            .withAncestor(
+                                4,
+                                PlatformPatterns.psiElement(PhpElementTypes.RETURN)
                             )
-                            .accepts(el)
                     )
+                    .accepts(el)
+                )
             );
         }
 
         return elements.stream()
-                .map(stringLiteral -> "\\" + ((StringLiteralExpression) stringLiteral).getContents())
-                .collect(Collectors.toSet());
+            .map(stringLiteral -> "\\" + ((StringLiteralExpression) stringLiteral).getContents())
+            .collect(Collectors.toSet());
     }
 }

--- a/typo3-cms/src/main/java/com/cedricziel/idea/typo3/extensionScanner/codeInspection/FunctionCallMatcherInspection.java
+++ b/typo3-cms/src/main/java/com/cedricziel/idea/typo3/extensionScanner/codeInspection/FunctionCallMatcherInspection.java
@@ -41,17 +41,13 @@ public class FunctionCallMatcherInspection extends PluginEnabledPhpInspection {
     public PsiElementVisitor buildRealVisitor(@NotNull ProblemsHolder problemsHolder, boolean b) {
         return new PhpElementVisitor() {
             @Override
-            public void visitPhpElement(PhpPsiElement element) {
-
-                if (!PlatformPatterns.psiElement(PhpElementTypes.FUNCTION_CALL).accepts(element)) {
-                    return;
+            public void visitPhpFunctionCall(FunctionReference reference) {
+                Set<String> constants = getRemovedGlobalFuntions(reference);
+                if (constants.contains(reference.getFQN())) {
+                    problemsHolder.registerProblem(reference, "Global function removed with TYPO3 9, consider using an alternative");
                 }
 
-                Set<String> constants = getRemovedGlobalFuntions(element);
-                FunctionReference constantReference = (FunctionReference) element;
-                if (constants.contains(constantReference.getFQN())) {
-                    problemsHolder.registerProblem(element, "Global function removed with TYPO3 9, consider using an alternative");
-                }
+                super.visitPhpFunctionCall(reference);
             }
         };
     }

--- a/typo3-cms/src/main/java/com/cedricziel/idea/typo3/extensionScanner/codeInspection/MethodArgumentDroppedMatcherInspection.java
+++ b/typo3-cms/src/main/java/com/cedricziel/idea/typo3/extensionScanner/codeInspection/MethodArgumentDroppedMatcherInspection.java
@@ -1,11 +1,11 @@
 package com.cedricziel.idea.typo3.extensionScanner.codeInspection;
 
+import com.cedricziel.idea.typo3.codeInspection.PluginEnabledPhpInspection;
 import com.cedricziel.idea.typo3.util.ExtensionScannerUtil;
 import com.intellij.codeInsight.daemon.GroupNames;
 import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.patterns.PlatformPatterns;
 import com.intellij.psi.PsiElementVisitor;
-import com.jetbrains.php.lang.inspections.PhpInspection;
 import com.jetbrains.php.lang.parser.PhpElementTypes;
 import com.jetbrains.php.lang.psi.elements.MethodReference;
 import com.jetbrains.php.lang.psi.elements.ParameterList;
@@ -16,7 +16,7 @@ import com.jetbrains.php.lang.psi.visitors.PhpElementVisitor;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 
-public class MethodArgumentDroppedMatcherInspection extends PhpInspection {
+public class MethodArgumentDroppedMatcherInspection extends PluginEnabledPhpInspection {
     @Nls
     @NotNull
     @Override
@@ -31,7 +31,7 @@ public class MethodArgumentDroppedMatcherInspection extends PhpInspection {
 
     @NotNull
     @Override
-    public PsiElementVisitor buildVisitor(@NotNull ProblemsHolder problemsHolder, boolean b) {
+    public PsiElementVisitor buildRealVisitor(@NotNull ProblemsHolder problemsHolder, boolean b) {
         return new PhpElementVisitor() {
             @Override
             public void visitPhpElement(PhpPsiElement element) {

--- a/typo3-cms/src/main/java/com/cedricziel/idea/typo3/extensionScanner/codeInspection/MethodArgumentDroppedMatcherInspection.java
+++ b/typo3-cms/src/main/java/com/cedricziel/idea/typo3/extensionScanner/codeInspection/MethodArgumentDroppedMatcherInspection.java
@@ -41,7 +41,7 @@ public class MethodArgumentDroppedMatcherInspection extends PluginEnabledPhpInsp
                         int maximumNumberOfArguments = ExtensionScannerUtil.getMaximumNumberOfArguments(reference.getProject(), compiledClassMethodKey);
 
                         if (parameterList != null && maximumNumberOfArguments != -1 && parameterList.getParameters().length != maximumNumberOfArguments) {
-                            problemsHolder.registerProblem(reference, "Number of arguments changed with TYPO3 9, consider refactoring");
+                            problemsHolder.registerProblem(reference, "Number of arguments changes with upcoming TYPO3 version, consider refactoring");
                         }
                     }
                 }

--- a/typo3-cms/src/main/java/com/cedricziel/idea/typo3/extensionScanner/codeInspection/MethodArgumentDroppedMatcherInspection.java
+++ b/typo3-cms/src/main/java/com/cedricziel/idea/typo3/extensionScanner/codeInspection/MethodArgumentDroppedMatcherInspection.java
@@ -4,13 +4,10 @@ import com.cedricziel.idea.typo3.codeInspection.PluginEnabledPhpInspection;
 import com.cedricziel.idea.typo3.util.ExtensionScannerUtil;
 import com.intellij.codeInsight.daemon.GroupNames;
 import com.intellij.codeInspection.ProblemsHolder;
-import com.intellij.patterns.PlatformPatterns;
 import com.intellij.psi.PsiElementVisitor;
-import com.jetbrains.php.lang.parser.PhpElementTypes;
 import com.jetbrains.php.lang.psi.elements.MethodReference;
 import com.jetbrains.php.lang.psi.elements.ParameterList;
 import com.jetbrains.php.lang.psi.elements.PhpExpression;
-import com.jetbrains.php.lang.psi.elements.PhpPsiElement;
 import com.jetbrains.php.lang.psi.resolve.types.PhpType;
 import com.jetbrains.php.lang.psi.visitors.PhpElementVisitor;
 import org.jetbrains.annotations.Nls;
@@ -34,26 +31,22 @@ public class MethodArgumentDroppedMatcherInspection extends PluginEnabledPhpInsp
     public PsiElementVisitor buildRealVisitor(@NotNull ProblemsHolder problemsHolder, boolean b) {
         return new PhpElementVisitor() {
             @Override
-            public void visitPhpElement(PhpPsiElement element) {
-
-                if (!PlatformPatterns.psiElement(PhpElementTypes.METHOD_REFERENCE).accepts(element)) {
-                    return;
-                }
-
-                MethodReference methodReference = (MethodReference) element;
-                ParameterList parameterList = methodReference.getParameterList();
-                PhpExpression classReference = methodReference.getClassReference();
+            public void visitPhpMethodReference(MethodReference reference) {
+                ParameterList parameterList = reference.getParameterList();
+                PhpExpression classReference = reference.getClassReference();
                 if (classReference != null) {
                     PhpType inferredType = classReference.getInferredType();
-                    String compiledClassMethodKey = inferredType.toString() + "->" + methodReference.getName();
-                    if (ExtensionScannerUtil.classMethodHasDroppedArguments(element.getProject(), compiledClassMethodKey)) {
-                        Integer maximumNumberOfArguments = ExtensionScannerUtil.getMaximumNumberOfArguments(element.getProject(), compiledClassMethodKey);
+                    String compiledClassMethodKey = inferredType.toString() + "->" + reference.getName();
+                    if (ExtensionScannerUtil.classMethodHasDroppedArguments(reference.getProject(), compiledClassMethodKey)) {
+                        int maximumNumberOfArguments = ExtensionScannerUtil.getMaximumNumberOfArguments(reference.getProject(), compiledClassMethodKey);
 
                         if (parameterList != null && maximumNumberOfArguments != -1 && parameterList.getParameters().length != maximumNumberOfArguments) {
-                            problemsHolder.registerProblem(element, "Number of arguments changed with TYPO3 9, consider refactoring");
+                            problemsHolder.registerProblem(reference, "Number of arguments changed with TYPO3 9, consider refactoring");
                         }
                     }
                 }
+
+                super.visitPhpMethodReference(reference);
             }
         };
     }

--- a/typo3-cms/src/main/java/com/cedricziel/idea/typo3/util/DeprecationUtility.java
+++ b/typo3-cms/src/main/java/com/cedricziel/idea/typo3/util/DeprecationUtility.java
@@ -10,18 +10,17 @@ import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.util.*;
 import com.jetbrains.php.lang.parser.PhpElementTypes;
 import com.jetbrains.php.lang.psi.elements.ClassConstantReference;
+import com.jetbrains.php.lang.psi.elements.PhpPsiElement;
 import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
 import com.jetbrains.php.lang.psi.elements.impl.ClassConstImpl;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class DeprecationUtility {
     private static final Key<CachedValue<Collection<String>>> DEPRECATED_CLASS_CONSTANTS = new Key<>("TYPO3_DEPRECATED_CLASS_CONSTANTS");
+    private static final Key<CachedValue<Collection<String>>> DEPRECATED_CLASSES = new Key<>("TYPO3_DEPRECATED_CLASSESS");
 
     public static boolean isDeprecated(@NotNull Project project, @NotNull ClassConstantReference constantReference) {
 
@@ -49,7 +48,7 @@ public class DeprecationUtility {
         return constants;
     }
 
-    public static Set<String> getDeprecatedClassConstantsFromFile(@NotNull PsiFile file) {
+    private static Set<String> getDeprecatedClassConstantsFromFile(@NotNull PsiFile file) {
         PsiElement[] elements = PsiTreeUtil.collectElements(file, el -> PlatformPatterns
             .psiElement(StringLiteralExpression.class)
             .withParent(
@@ -66,6 +65,39 @@ public class DeprecationUtility {
             .map(stringLiteral -> ((StringLiteralExpression) stringLiteral).getContents())
             .map(s -> "\\" + s)
             .map(s -> s.replace("::", "."))
+            .collect(Collectors.toSet());
+    }
+
+    public static Set<String> getDeprecatedClassNames(@NotNull Project project) {
+        Set<String> classNames = new HashSet<>();
+
+        PsiFile[] classNameMatcherFiles = FilenameIndex.getFilesByName(project, "ClassNameMatcher.php", GlobalSearchScope.allScope(project));
+        for (PsiFile file : classNameMatcherFiles) {
+            classNames.addAll(CachedValuesManager.getManager(project).getCachedValue(
+                file,
+                DEPRECATED_CLASSES,
+                () -> CachedValueProvider.Result.create(getDeprecatedClassNamesFromFile(file), PsiModificationTracker.MODIFICATION_COUNT),
+                false
+            ));
+        }
+
+        return classNames;
+    }
+
+    private static Set<String> getDeprecatedClassNamesFromFile(@NotNull PsiFile file) {
+        PsiElement[] elements = PsiTreeUtil.collectElements(file, el -> PlatformPatterns
+            .psiElement(StringLiteralExpression.class)
+            .withParent(
+                PlatformPatterns.psiElement(PhpElementTypes.ARRAY_KEY)
+                    .withAncestor(
+                        4,
+                        PlatformPatterns.psiElement(PhpElementTypes.RETURN)
+                    )
+            )
+            .accepts(el));
+
+        return Arrays.stream(elements)
+            .map(stringLiteral -> "\\" + ((StringLiteralExpression) stringLiteral).getContents())
             .collect(Collectors.toSet());
     }
 }

--- a/typo3-cms/src/main/java/com/cedricziel/idea/typo3/util/DeprecationUtility.java
+++ b/typo3-cms/src/main/java/com/cedricziel/idea/typo3/util/DeprecationUtility.java
@@ -11,6 +11,7 @@ import com.intellij.psi.util.*;
 import com.jetbrains.php.lang.parser.PhpElementTypes;
 import com.jetbrains.php.lang.psi.elements.ClassConstantReference;
 import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
+import com.jetbrains.php.lang.psi.elements.impl.ClassConstImpl;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
@@ -22,8 +23,15 @@ import java.util.stream.Collectors;
 public class DeprecationUtility {
     private static final Key<CachedValue<Collection<String>>> DEPRECATED_CLASS_CONSTANTS = new Key<>("TYPO3_DEPRECATED_CLASS_CONSTANTS");
 
-    public static boolean isDeprecated(Project project, ClassConstantReference constantReference) {
-        return getDeprecatedClassConstants(project).contains(constantReference.getText());
+    public static boolean isDeprecated(@NotNull Project project, @NotNull ClassConstantReference constantReference) {
+
+        ClassConstImpl classConst = (ClassConstImpl) constantReference.resolve();
+        if (classConst == null) {
+            return false;
+        }
+
+        String fqn = classConst.getFQN();
+        return getDeprecatedClassConstants(project).contains(fqn);
     }
 
     public static Set<String> getDeprecatedClassConstants(@NotNull Project project) {
@@ -56,6 +64,8 @@ public class DeprecationUtility {
 
         return Arrays.stream(elements)
             .map(stringLiteral -> ((StringLiteralExpression) stringLiteral).getContents())
+            .map(s -> "\\" + s)
+            .map(s -> s.replace("::", "."))
             .collect(Collectors.toSet());
     }
 }

--- a/typo3-cms/src/test/java/com/cedricziel/idea/typo3/extensionScanner/codeInspection/ClassConstantMatcherInspectionTest.java
+++ b/typo3-cms/src/test/java/com/cedricziel/idea/typo3/extensionScanner/codeInspection/ClassConstantMatcherInspectionTest.java
@@ -15,6 +15,6 @@ public class ClassConstantMatcherInspectionTest extends AbstractTestCase {
         myFixture.copyFileToProject("ClassConstantMatcher.php", "foo/ClassConstantMatcher.php");
         myFixture.copyFileToProject("ClassConstantMatcher2.php", "bar/ClassConstantMatcher.php");
 
-        myFixture.testHighlighting("deprecated_constant_usage.php");
+        myFixture.testHighlighting("deprecated_class_constant_usage.php");
     }
 }

--- a/typo3-cms/src/test/java/com/cedricziel/idea/typo3/extensionScanner/codeInspection/ClassConstantMatcherInspectionTest.java
+++ b/typo3-cms/src/test/java/com/cedricziel/idea/typo3/extensionScanner/codeInspection/ClassConstantMatcherInspectionTest.java
@@ -1,0 +1,20 @@
+package com.cedricziel.idea.typo3.extensionScanner.codeInspection;
+
+import com.cedricziel.idea.typo3.AbstractTestCase;
+
+public class ClassConstantMatcherInspectionTest extends AbstractTestCase {
+    @Override
+    protected String getTestDataPath() {
+        return super.getTestDataPath() + "/extensionScanner/codeInspection";
+    }
+
+    public void testUsageOfDeprecatedClassConstantsIsHighlighted() {
+        myFixture.enableInspections(new ClassConstantMatcherInspection());
+
+        myFixture.copyFileToProject("classes.php");
+        myFixture.copyFileToProject("ClassConstantMatcher.php", "foo/ClassConstantMatcher.php");
+        myFixture.copyFileToProject("ClassConstantMatcher2.php", "bar/ClassConstantMatcher.php");
+
+        myFixture.testHighlighting("deprecated_constant_usage.php");
+    }
+}

--- a/typo3-cms/src/test/java/com/cedricziel/idea/typo3/extensionScanner/codeInspection/ClassNameMatcherInspectionTest.java
+++ b/typo3-cms/src/test/java/com/cedricziel/idea/typo3/extensionScanner/codeInspection/ClassNameMatcherInspectionTest.java
@@ -1,0 +1,21 @@
+package com.cedricziel.idea.typo3.extensionScanner.codeInspection;
+
+import com.cedricziel.idea.typo3.AbstractTestCase;
+
+public class ClassNameMatcherInspectionTest extends AbstractTestCase {
+    @Override
+    protected String getTestDataPath() {
+        return super.getTestDataPath() + "/extensionScanner/codeInspection";
+    }
+
+    public void testUsageOfDeprecatedClassConstantsIsHighlighted() {
+        myFixture.enableInspections(new ClassNameMatcherInspection());
+
+        myFixture.copyFileToProject("classes.php");
+        myFixture.copyFileToProject("ClassNameMatcher.php", "foo/ClassNameMatcher.php");
+        myFixture.copyFileToProject("ClassNameMatcher2.php", "bar/ClassNameMatcher.php");
+
+        myFixture.testHighlighting("deprecated_class_name_usage.php");
+        myFixture.testHighlighting("deprecated_class_name_usage_import.php");
+    }
+}

--- a/typo3-cms/src/test/java/com/cedricziel/idea/typo3/extensionScanner/codeInspection/ConstantMatcherInspectionTest.java
+++ b/typo3-cms/src/test/java/com/cedricziel/idea/typo3/extensionScanner/codeInspection/ConstantMatcherInspectionTest.java
@@ -1,0 +1,21 @@
+package com.cedricziel.idea.typo3.extensionScanner.codeInspection;
+
+import com.cedricziel.idea.typo3.AbstractTestCase;
+import junit.framework.TestCase;
+
+public class ConstantMatcherInspectionTest extends AbstractTestCase {
+    @Override
+    protected String getTestDataPath() {
+        return super.getTestDataPath() + "/extensionScanner/codeInspection";
+    }
+
+    public void testUsageOfDeprecatedConstantsIsHighlighted() {
+        myFixture.enableInspections(new ConstantMatcherInspection());
+
+        myFixture.copyFileToProject("classes.php");
+        myFixture.copyFileToProject("ConstantMatcher.php", "foo/ConstantMatcher.php");
+        myFixture.copyFileToProject("ConstantMatcher2.php", "bar/ConstantMatcher.php");
+
+        myFixture.testHighlighting("deprecated_constant_usage.php");
+    }
+}

--- a/typo3-cms/src/test/java/com/cedricziel/idea/typo3/extensionScanner/codeInspection/FunctionCallMatcherInspectionTest.java
+++ b/typo3-cms/src/test/java/com/cedricziel/idea/typo3/extensionScanner/codeInspection/FunctionCallMatcherInspectionTest.java
@@ -1,0 +1,20 @@
+package com.cedricziel.idea.typo3.extensionScanner.codeInspection;
+
+import com.cedricziel.idea.typo3.AbstractTestCase;
+
+public class FunctionCallMatcherInspectionTest extends AbstractTestCase {
+    @Override
+    protected String getTestDataPath() {
+        return super.getTestDataPath() + "/extensionScanner/codeInspection";
+    }
+
+    public void testUsageOfDeprecatedFunctionCalls() {
+        myFixture.enableInspections(new FunctionCallMatcherInspection());
+
+        myFixture.copyFileToProject("classes.php");
+        myFixture.copyFileToProject("FunctionCallMatcher.php", "foo/FunctionCallMatcher.php");
+        myFixture.copyFileToProject("FunctionCallMatcher2.php", "bar/FunctionCallMatcher.php");
+
+        myFixture.testHighlighting("deprecated_function_call.php");
+    }
+}

--- a/typo3-cms/src/test/java/com/cedricziel/idea/typo3/extensionScanner/codeInspection/MethodArgumentDroppedMatcherInspectionTest.java
+++ b/typo3-cms/src/test/java/com/cedricziel/idea/typo3/extensionScanner/codeInspection/MethodArgumentDroppedMatcherInspectionTest.java
@@ -1,0 +1,22 @@
+package com.cedricziel.idea.typo3.extensionScanner.codeInspection;
+
+import com.cedricziel.idea.typo3.AbstractTestCase;
+import junit.framework.TestCase;
+
+public class MethodArgumentDroppedMatcherInspectionTest extends AbstractTestCase {
+    @Override
+    protected String getTestDataPath() {
+        return super.getTestDataPath() + "/extensionScanner/codeInspection";
+    }
+
+    public void testUsageOfDroppedArgumentsInspection() {
+        myFixture.enableInspections(new MethodArgumentDroppedMatcherInspection());
+
+        myFixture.copyFileToProject("classes.php");
+        myFixture.copyFileToProject("MethodArgumentDroppedMatcher.php", "foo/MethodArgumentDroppedMatcher.php");
+        myFixture.copyFileToProject("MethodArgumentDroppedMatcher2.php", "bar/MethodArgumentDroppedMatcher.php");
+
+        myFixture.testHighlighting("deprecated_number_of_arguments_dropped_matching.php");
+        myFixture.testHighlighting("deprecated_number_of_arguments_dropped_too_many.php");
+    }
+}

--- a/typo3-cms/src/test/java/com/cedricziel/idea/typo3/util/DeprecationUtilityTest.java
+++ b/typo3-cms/src/test/java/com/cedricziel/idea/typo3/util/DeprecationUtilityTest.java
@@ -61,4 +61,22 @@ public class DeprecationUtilityTest extends AbstractTestCase {
                 myFixture.getProject()).contains("\\BAR")
         );
     }
+
+    public void testDeprecatedFunctionCallsCanBeFound() {
+        myFixture.copyFileToProject("FunctionCallMatcher.php", "foo/FunctionCallMatcher.php");
+        myFixture.copyFileToProject("FunctionCallMatcher2.php", "bar/FunctionCallMatcher.php");
+
+        assertTrue(
+            DeprecationUtility.getDeprecatedGlobalFunctionCalls(
+                myFixture.getProject()).contains("\\debugEnd")
+        );
+        assertTrue(
+            DeprecationUtility.getDeprecatedGlobalFunctionCalls(
+                myFixture.getProject()).contains("\\debug")
+        );
+        assertFalse(
+            DeprecationUtility.getDeprecatedGlobalFunctionCalls(
+                myFixture.getProject()).contains("\\file_get_contents")
+        );
+    }
 }

--- a/typo3-cms/src/test/java/com/cedricziel/idea/typo3/util/DeprecationUtilityTest.java
+++ b/typo3-cms/src/test/java/com/cedricziel/idea/typo3/util/DeprecationUtilityTest.java
@@ -25,4 +25,22 @@ public class DeprecationUtilityTest extends AbstractTestCase {
                 myFixture.getProject()).contains("\\TYPO3\\CMS\\Backend\\Template\\DocumentTemplate.GOOD_CATCH")
         );
     }
+
+    public void testDeprecatedClassNamesCanBeFound() {
+        myFixture.copyFileToProject("ClassNameMatcher.php", "foo/ClassNameMatcher.php");
+        myFixture.copyFileToProject("ClassNameMatcher2.php", "bar/ClassNameMatcher.php");
+
+        assertTrue(
+            DeprecationUtility.getDeprecatedClassNames(
+                myFixture.getProject()).contains("\\RemoveXSS")
+        );
+        assertTrue(
+            DeprecationUtility.getDeprecatedClassNames(
+                myFixture.getProject()).contains("\\TYPO3\\CMS\\Backend\\Console\\CliRequestHandler")
+        );
+        assertFalse(
+            DeprecationUtility.getDeprecatedClassNames(
+                myFixture.getProject()).contains("\\App\\Apple")
+        );
+    }
 }

--- a/typo3-cms/src/test/java/com/cedricziel/idea/typo3/util/DeprecationUtilityTest.java
+++ b/typo3-cms/src/test/java/com/cedricziel/idea/typo3/util/DeprecationUtilityTest.java
@@ -43,4 +43,22 @@ public class DeprecationUtilityTest extends AbstractTestCase {
                 myFixture.getProject()).contains("\\App\\Apple")
         );
     }
+
+    public void testDeprecatedConstantsCanBeFound() {
+        myFixture.copyFileToProject("ConstantMatcher.php", "foo/ConstantMatcher.php");
+        myFixture.copyFileToProject("ConstantMatcher2.php", "bar/ConstantMatcher.php");
+
+        assertTrue(
+            DeprecationUtility.getDeprecatedConstantNames(
+                myFixture.getProject()).contains("\\TYPO3_DLOG")
+        );
+        assertTrue(
+            DeprecationUtility.getDeprecatedConstantNames(
+                myFixture.getProject()).contains("\\TYPO3_user_agent")
+        );
+        assertFalse(
+            DeprecationUtility.getDeprecatedConstantNames(
+                myFixture.getProject()).contains("\\BAR")
+        );
+    }
 }

--- a/typo3-cms/src/test/java/com/cedricziel/idea/typo3/util/DeprecationUtilityTest.java
+++ b/typo3-cms/src/test/java/com/cedricziel/idea/typo3/util/DeprecationUtilityTest.java
@@ -14,15 +14,15 @@ public class DeprecationUtilityTest extends AbstractTestCase {
 
         assertTrue(
             DeprecationUtility.getDeprecatedClassConstants(
-                myFixture.getProject()).contains("TYPO3\\CMS\\Backend\\Template\\DocumentTemplate::STATUS_ICON_ERROR")
+                myFixture.getProject()).contains("\\TYPO3\\CMS\\Backend\\Template\\DocumentTemplate.STATUS_ICON_ERROR")
         );
         assertTrue(
             DeprecationUtility.getDeprecatedClassConstants(
-                myFixture.getProject()).contains("TYPO3\\CMS\\Backend\\Template\\DocumentTemplate::STATUS_ICON_OK")
+                myFixture.getProject()).contains("\\TYPO3\\CMS\\Backend\\Template\\DocumentTemplate.STATUS_ICON_OK")
         );
         assertFalse(
             DeprecationUtility.getDeprecatedClassConstants(
-                myFixture.getProject()).contains("TYPO3\\CMS\\Backend\\Template\\DocumentTemplate::GOOD_CATCH")
+                myFixture.getProject()).contains("\\TYPO3\\CMS\\Backend\\Template\\DocumentTemplate.GOOD_CATCH")
         );
     }
 }

--- a/typo3-cms/src/test/java/com/cedricziel/idea/typo3/util/DeprecationUtilityTest.java
+++ b/typo3-cms/src/test/java/com/cedricziel/idea/typo3/util/DeprecationUtilityTest.java
@@ -1,0 +1,28 @@
+package com.cedricziel.idea.typo3.util;
+
+import com.cedricziel.idea.typo3.AbstractTestCase;
+
+public class DeprecationUtilityTest extends AbstractTestCase {
+    @Override
+    protected String getTestDataPath() {
+        return "testData/com/cedricziel/idea/typo3/util";
+    }
+
+    public void testDeprecatedClassConstantsCanBeFound() {
+        myFixture.copyFileToProject("ClassConstantMatcher.php", "foo/ClassConstantMatcher.php");
+        myFixture.copyFileToProject("ClassConstantMatcher2.php", "bar/ClassConstantMatcher.php");
+
+        assertTrue(
+            DeprecationUtility.getDeprecatedClassConstants(
+                myFixture.getProject()).contains("TYPO3\\CMS\\Backend\\Template\\DocumentTemplate::STATUS_ICON_ERROR")
+        );
+        assertTrue(
+            DeprecationUtility.getDeprecatedClassConstants(
+                myFixture.getProject()).contains("TYPO3\\CMS\\Backend\\Template\\DocumentTemplate::STATUS_ICON_OK")
+        );
+        assertFalse(
+            DeprecationUtility.getDeprecatedClassConstants(
+                myFixture.getProject()).contains("TYPO3\\CMS\\Backend\\Template\\DocumentTemplate::GOOD_CATCH")
+        );
+    }
+}

--- a/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/ClassConstantMatcher.php
+++ b/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/ClassConstantMatcher.php
@@ -1,0 +1,13 @@
+<?php
+return [
+    'TYPO3\CMS\Backend\Template\DocumentTemplate::STATUS_ICON_ERROR' => [
+        'restFiles' => [
+            'Breaking-80700-DeprecatedFunctionalityRemoved.rst',
+        ],
+    ],
+    'TYPO3\CMS\Backend\Template\DocumentTemplate::STATUS_ICON_WARNING' => [
+        'restFiles' => [
+            'Breaking-80700-DeprecatedFunctionalityRemoved.rst',
+        ],
+    ],
+];

--- a/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/ClassConstantMatcher2.php
+++ b/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/ClassConstantMatcher2.php
@@ -1,0 +1,13 @@
+<?php
+return [
+    'TYPO3\CMS\Backend\Template\DocumentTemplate::STATUS_ICON_NOTIFICATION' => [
+        'restFiles' => [
+            'Breaking-80700-DeprecatedFunctionalityRemoved.rst',
+        ],
+    ],
+    'TYPO3\CMS\Backend\Template\DocumentTemplate::STATUS_ICON_OK' => [
+        'restFiles' => [
+            'Breaking-80700-DeprecatedFunctionalityRemoved.rst',
+        ],
+    ],
+];

--- a/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/ClassNameMatcher.php
+++ b/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/ClassNameMatcher.php
@@ -1,0 +1,16 @@
+<?php
+return [
+    // Removed classes
+    'RemoveXSS' => [
+        'restFiles' => [
+            'Breaking-80700-DeprecatedFunctionalityRemoved.rst',
+            'Deprecation-76164-DeprecateRemoveXSS.rst',
+        ],
+    ],
+    'TYPO3\CMS\Backend\Console\Application' => [
+        'restFiles' => [
+            'Breaking-80700-DeprecatedFunctionalityRemoved.rst',
+            'Deprecation-80468-CommandLineInterfaceCliKeysAndCli_dispatchphpsh.rst',
+        ],
+    ],
+];

--- a/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/ClassNameMatcher2.php
+++ b/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/ClassNameMatcher2.php
@@ -1,0 +1,16 @@
+<?php
+return [
+    // Removed classes
+    'TYPO3\CMS\Backend\Console\CliRequestHandler' => [
+        'restFiles' => [
+            'Breaking-80700-DeprecatedFunctionalityRemoved.rst',
+            'Deprecation-80468-CommandLineInterfaceCliKeysAndCli_dispatchphpsh.rst',
+        ],
+    ],
+    'TYPO3\CMS\Backend\Controller\Wizard\ColorpickerController' => [
+        'restFiles' => [
+            'Breaking-80700-DeprecatedFunctionalityRemoved.rst',
+            'Deprecation-78899-FormEngineMethods.rst',
+        ],
+    ],
+];

--- a/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/ConstantMatcher.php
+++ b/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/ConstantMatcher.php
@@ -1,0 +1,13 @@
+<?php
+return [
+    'TYPO3_DLOG' => [
+        'restFiles' => [
+            'Breaking-82162-GlobalErrorConstantsRemoved.rst',
+        ],
+    ],
+    'TYPO3_ERROR_DLOG' => [
+        'restFiles' => [
+            'Breaking-82162-GlobalErrorConstantsRemoved.rst',
+        ],
+    ],
+];

--- a/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/ConstantMatcher2.php
+++ b/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/ConstantMatcher2.php
@@ -1,0 +1,13 @@
+<?php
+return [
+    'TYPO3_EXCEPTION_DLOG' => [
+        'restFiles' => [
+            'Breaking-82162-GlobalErrorConstantsRemoved.rst',
+        ],
+    ],
+    'TYPO3_user_agent' => [
+        'restFiles' => [
+            'Breaking-82296-UserAgentConstantRemoved.rst',
+        ],
+    ],
+];

--- a/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/FunctionCallMatcher.php
+++ b/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/FunctionCallMatcher.php
@@ -1,0 +1,18 @@
+<?php
+return [
+    // Removed global functions
+    'debugBegin' => [
+        'numberOfMandatoryArguments' => 0,
+        'maximumNumberOfArguments' => 0,
+        'restFiles' => [
+            'Breaking-37180-RemovedExtDirectDebugAndGLOBALSerror.rst',
+        ],
+    ],
+    'debugEnd' => [
+        'numberOfMandatoryArguments' => 0,
+        'maximumNumberOfArguments' => 0,
+        'restFiles' => [
+            'Breaking-37180-RemovedExtDirectDebugAndGLOBALSerror.rst',
+        ],
+    ],
+];

--- a/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/FunctionCallMatcher2.php
+++ b/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/FunctionCallMatcher2.php
@@ -1,0 +1,17 @@
+<?php
+return [
+    'xdebug' => [
+        'numberOfMandatoryArguments' => 0,
+        'maximumNumberOfArguments' => 0,
+        'restFiles' => [
+            'Breaking-82640-Re-arrangingGlobalDebugFunctions.rst',
+        ],
+    ],
+    'debug' => [
+        'numberOfMandatoryArguments' => 0,
+        'maximumNumberOfArguments' => 3,
+        'restFiles' => [
+            'Breaking-82640-Re-arrangingGlobalDebugFunctions.rst',
+        ],
+    ],
+];

--- a/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/MethodArgumentDroppedMatcher.php
+++ b/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/MethodArgumentDroppedMatcher.php
@@ -1,0 +1,15 @@
+<?php
+return [
+    'TYPO3\CMS\Core\Charset\CharsetConverter->euc_char_mapping' => [
+        'maximumNumberOfArguments' => 2,
+        'restFiles' => [
+            'Breaking-80700-DeprecatedFunctionalityRemoved.rst',
+        ],
+    ],
+    'TYPO3\CMS\Core\Charset\CharsetConverter->sb_char_mapping' => [
+        'maximumNumberOfArguments' => 2,
+        'restFiles' => [
+            'Breaking-80700-DeprecatedFunctionalityRemoved.rst',
+        ],
+    ],
+];

--- a/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/MethodArgumentDroppedMatcher2.php
+++ b/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/MethodArgumentDroppedMatcher2.php
@@ -1,0 +1,16 @@
+<?php
+return [
+    'TYPO3\CMS\Core\Charset\CharsetConverter->utf8_char_mapping' => [
+        'maximumNumberOfArguments' => 1,
+        'restFiles' => [
+            'Breaking-80700-DeprecatedFunctionalityRemoved.rst',
+        ],
+    ],
+    'TYPO3\CMS\Core\DataHandling\DataHandler->extFileFunctions' => [
+        'maximumNumberOfArguments' => 3,
+        'restFiles' => [
+            'Breaking-80700-DeprecatedFunctionalityRemoved.rst',
+            'Deprecation-80513-DataHandlerVariousMethodsAndMethodArguments.rst',
+        ],
+    ],
+];

--- a/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/classes.php
+++ b/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/classes.php
@@ -1,4 +1,7 @@
 <?php
+namespace {
+    define('TYPO3_ERROR_DLOG', 'foo');
+}
 
 namespace TYPO3\CMS\Backend\Template {
     class DocumentTemplate {

--- a/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/classes.php
+++ b/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/classes.php
@@ -1,6 +1,8 @@
 <?php
 namespace {
     define('TYPO3_ERROR_DLOG', 'foo');
+
+    function debugEnd() {}
 }
 
 namespace TYPO3\CMS\Backend\Template {

--- a/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/classes.php
+++ b/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/classes.php
@@ -5,6 +5,23 @@ namespace {
     function debugEnd() {}
 }
 
+namespace TYPO3\CMS\Core\Charset {
+    class CharsetConverter {
+        public function euc_char_mapping($str, $charset)
+        {
+        }
+    }
+}
+
+namespace TYPO3\CMS\Core\DataHandling {
+    class DataHandler {
+        public function extFileFunctions($table, $field, $filelist)
+        {
+
+        }
+    }
+}
+
 namespace TYPO3\CMS\Backend\Template {
     class DocumentTemplate {
         const STATUS_ICON_OK = 'foo';

--- a/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/classes.php
+++ b/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/classes.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace TYPO3\CMS\Backend\Template {
+    class DocumentTemplate {
+        const STATUS_ICON_OK = 'foo';
+    }
+}

--- a/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/classes.php
+++ b/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/classes.php
@@ -5,3 +5,7 @@ namespace TYPO3\CMS\Backend\Template {
         const STATUS_ICON_OK = 'foo';
     }
 }
+
+namespace TYPO3\CMS\Backend\Controller\Wizard {
+    class ColorpickerController {}
+}

--- a/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/deprecated_class_constant_usage.php
+++ b/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/deprecated_class_constant_usage.php
@@ -1,0 +1,3 @@
+<?php
+
+<warning descr="Deprecated class constant">\TYPO3\CMS\Backend\Template\DocumentTemplate::STATUS_ICON_OK</warning>;

--- a/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/deprecated_class_name_usage.php
+++ b/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/deprecated_class_name_usage.php
@@ -1,0 +1,3 @@
+<?php
+
+new <warning descr="Class scheduled for removal in upcoming TYPO3 version, consider using an alternative">\TYPO3\CMS\Backend\Controller\Wizard\ColorpickerController</warning>();

--- a/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/deprecated_class_name_usage_import.php
+++ b/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/deprecated_class_name_usage_import.php
@@ -1,0 +1,5 @@
+<?php
+
+use <warning descr="Class scheduled for removal in upcoming TYPO3 version, consider using an alternative">TYPO3\CMS\Backend\Controller\Wizard\ColorpickerController</warning> as SizepickerController;
+
+new <warning descr="Class scheduled for removal in upcoming TYPO3 version, consider using an alternative">SizepickerController</warning>();

--- a/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/deprecated_constant_usage.php
+++ b/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/deprecated_constant_usage.php
@@ -1,0 +1,3 @@
+<?php
+
+<warning descr="Deprecated class constant">\TYPO3\CMS\Backend\Template\DocumentTemplate::STATUS_ICON_OK</warning>;

--- a/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/deprecated_constant_usage.php
+++ b/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/deprecated_constant_usage.php
@@ -1,3 +1,5 @@
 <?php
 
-<warning descr="Deprecated class constant">\TYPO3\CMS\Backend\Template\DocumentTemplate::STATUS_ICON_OK</warning>;
+if (<warning descr="Constant scheduled for removal in upcoming TYPO3 version, consider using an alternative">TYPO3_ERROR_DLOG</warning>) {
+    echo "foo";
+}

--- a/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/deprecated_function_call.php
+++ b/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/deprecated_function_call.php
@@ -1,0 +1,2 @@
+<?php
+<warning descr="Global function scheduled for removal in upcoming TYPO3 version, consider using an alternative">debugEnd()</warning>;

--- a/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/deprecated_number_of_arguments_dropped_matching.php
+++ b/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/deprecated_number_of_arguments_dropped_matching.php
@@ -1,0 +1,4 @@
+<?php
+
+$converter = new \TYPO3\CMS\Core\Charset\CharsetConverter();
+$converter->euc_char_mapping('foo', 'bar');

--- a/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/deprecated_number_of_arguments_dropped_too_many.php
+++ b/typo3-cms/testData/com/cedricziel/idea/typo3/extensionScanner/codeInspection/deprecated_number_of_arguments_dropped_too_many.php
@@ -1,0 +1,6 @@
+<?php
+
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+
+$dh = new DataHandler();
+<warning descr="Number of arguments changes with upcoming TYPO3 version, consider refactoring">$dh->extFileFunctions('foo', 'bar', 'baz', 'bongo')</warning>;

--- a/typo3-cms/testData/com/cedricziel/idea/typo3/util/ClassConstantMatcher.php
+++ b/typo3-cms/testData/com/cedricziel/idea/typo3/util/ClassConstantMatcher.php
@@ -1,0 +1,13 @@
+<?php
+return [
+    'TYPO3\CMS\Backend\Template\DocumentTemplate::STATUS_ICON_ERROR' => [
+        'restFiles' => [
+            'Breaking-80700-DeprecatedFunctionalityRemoved.rst',
+        ],
+    ],
+    'TYPO3\CMS\Backend\Template\DocumentTemplate::STATUS_ICON_WARNING' => [
+        'restFiles' => [
+            'Breaking-80700-DeprecatedFunctionalityRemoved.rst',
+        ],
+    ],
+];

--- a/typo3-cms/testData/com/cedricziel/idea/typo3/util/ClassConstantMatcher2.php
+++ b/typo3-cms/testData/com/cedricziel/idea/typo3/util/ClassConstantMatcher2.php
@@ -1,0 +1,13 @@
+<?php
+return [
+    'TYPO3\CMS\Backend\Template\DocumentTemplate::STATUS_ICON_NOTIFICATION' => [
+        'restFiles' => [
+            'Breaking-80700-DeprecatedFunctionalityRemoved.rst',
+        ],
+    ],
+    'TYPO3\CMS\Backend\Template\DocumentTemplate::STATUS_ICON_OK' => [
+        'restFiles' => [
+            'Breaking-80700-DeprecatedFunctionalityRemoved.rst',
+        ],
+    ],
+];

--- a/typo3-cms/testData/com/cedricziel/idea/typo3/util/ClassNameMatcher.php
+++ b/typo3-cms/testData/com/cedricziel/idea/typo3/util/ClassNameMatcher.php
@@ -1,0 +1,16 @@
+<?php
+return [
+    // Removed classes
+    'RemoveXSS' => [
+        'restFiles' => [
+            'Breaking-80700-DeprecatedFunctionalityRemoved.rst',
+            'Deprecation-76164-DeprecateRemoveXSS.rst',
+        ],
+    ],
+    'TYPO3\CMS\Backend\Console\Application' => [
+        'restFiles' => [
+            'Breaking-80700-DeprecatedFunctionalityRemoved.rst',
+            'Deprecation-80468-CommandLineInterfaceCliKeysAndCli_dispatchphpsh.rst',
+        ],
+    ],
+];

--- a/typo3-cms/testData/com/cedricziel/idea/typo3/util/ClassNameMatcher2.php
+++ b/typo3-cms/testData/com/cedricziel/idea/typo3/util/ClassNameMatcher2.php
@@ -1,0 +1,16 @@
+<?php
+return [
+    // Removed classes
+    'TYPO3\CMS\Backend\Console\CliRequestHandler' => [
+        'restFiles' => [
+            'Breaking-80700-DeprecatedFunctionalityRemoved.rst',
+            'Deprecation-80468-CommandLineInterfaceCliKeysAndCli_dispatchphpsh.rst',
+        ],
+    ],
+    'TYPO3\CMS\Backend\Controller\Wizard\ColorpickerController' => [
+        'restFiles' => [
+            'Breaking-80700-DeprecatedFunctionalityRemoved.rst',
+            'Deprecation-78899-FormEngineMethods.rst',
+        ],
+    ],
+];

--- a/typo3-cms/testData/com/cedricziel/idea/typo3/util/ConstantMatcher.php
+++ b/typo3-cms/testData/com/cedricziel/idea/typo3/util/ConstantMatcher.php
@@ -1,0 +1,13 @@
+<?php
+return [
+    'TYPO3_DLOG' => [
+        'restFiles' => [
+            'Breaking-82162-GlobalErrorConstantsRemoved.rst',
+        ],
+    ],
+    'TYPO3_ERROR_DLOG' => [
+        'restFiles' => [
+            'Breaking-82162-GlobalErrorConstantsRemoved.rst',
+        ],
+    ],
+];

--- a/typo3-cms/testData/com/cedricziel/idea/typo3/util/ConstantMatcher2.php
+++ b/typo3-cms/testData/com/cedricziel/idea/typo3/util/ConstantMatcher2.php
@@ -1,0 +1,13 @@
+<?php
+return [
+    'TYPO3_EXCEPTION_DLOG' => [
+        'restFiles' => [
+            'Breaking-82162-GlobalErrorConstantsRemoved.rst',
+        ],
+    ],
+    'TYPO3_user_agent' => [
+        'restFiles' => [
+            'Breaking-82296-UserAgentConstantRemoved.rst',
+        ],
+    ],
+];

--- a/typo3-cms/testData/com/cedricziel/idea/typo3/util/FunctionCallMatcher.php
+++ b/typo3-cms/testData/com/cedricziel/idea/typo3/util/FunctionCallMatcher.php
@@ -1,0 +1,18 @@
+<?php
+return [
+    // Removed global functions
+    'debugBegin' => [
+        'numberOfMandatoryArguments' => 0,
+        'maximumNumberOfArguments' => 0,
+        'restFiles' => [
+            'Breaking-37180-RemovedExtDirectDebugAndGLOBALSerror.rst',
+        ],
+    ],
+    'debugEnd' => [
+        'numberOfMandatoryArguments' => 0,
+        'maximumNumberOfArguments' => 0,
+        'restFiles' => [
+            'Breaking-37180-RemovedExtDirectDebugAndGLOBALSerror.rst',
+        ],
+    ],
+];

--- a/typo3-cms/testData/com/cedricziel/idea/typo3/util/FunctionCallMatcher2.php
+++ b/typo3-cms/testData/com/cedricziel/idea/typo3/util/FunctionCallMatcher2.php
@@ -1,0 +1,17 @@
+<?php
+return [
+    'xdebug' => [
+        'numberOfMandatoryArguments' => 0,
+        'maximumNumberOfArguments' => 0,
+        'restFiles' => [
+            'Breaking-82640-Re-arrangingGlobalDebugFunctions.rst',
+        ],
+    ],
+    'debug' => [
+        'numberOfMandatoryArguments' => 0,
+        'maximumNumberOfArguments' => 3,
+        'restFiles' => [
+            'Breaking-82640-Re-arrangingGlobalDebugFunctions.rst',
+        ],
+    ],
+];


### PR DESCRIPTION
We had (and probably still have) a lot of inspections/code that were/was
created in the very early days of the plugin.

Some of these were matching plain text or simply used wrong logic.

This changeset aims to do the following:

* correct inspection behaviour, secure with tests
* only enable inspections when the plugin is active for the current project