### PR TITLE
[T3CMS] Suppress unused inspection for extbase controllers

### DIFF
--- a/lang-fluid/src/main/java/com/cedricziel/idea/fluid/util/FluidUtil.java
+++ b/lang-fluid/src/main/java/com/cedricziel/idea/fluid/util/FluidUtil.java
@@ -166,9 +166,17 @@ public class FluidUtil {
     public static Collection<FluidFile> findTemplatesForControllerAction(Method method) {
         List<FluidFile> fluidFiles = new ArrayList<>();
 
+        if (!method.getName().endsWith("Action") && !method.getName().equals("Action")) {
+            return fluidFiles;
+        }
+
         String fileName = method.getName().substring(0, 1).toUpperCase() + method.getName().substring(1, method.getName().length() - "Action".length());
         PhpClass containingClass = method.getContainingClass();
         if (containingClass == null) {
+            return fluidFiles;
+        }
+
+        if (!containingClass.getName().endsWith("Controller") && !containingClass.getName().equals("Controller")) {
             return fluidFiles;
         }
 

--- a/typo3-cms/src/main/java/com/cedricziel/idea/typo3/codeInspection/UnusedActionControllerMethodInspectionSuppressor.java
+++ b/typo3-cms/src/main/java/com/cedricziel/idea/typo3/codeInspection/UnusedActionControllerMethodInspectionSuppressor.java
@@ -1,0 +1,60 @@
+package com.cedricziel.idea.typo3.codeInspection;
+
+import com.intellij.codeInspection.InspectionSuppressor;
+import com.intellij.codeInspection.SuppressQuickFix;
+import com.intellij.patterns.PlatformPatterns;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.jetbrains.php.PhpIndex;
+import com.jetbrains.php.lang.psi.elements.Method;
+import com.jetbrains.php.lang.psi.elements.PhpClass;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class UnusedActionControllerMethodInspectionSuppressor implements InspectionSuppressor {
+    @Override
+    public boolean isSuppressedFor(@NotNull PsiElement element, @NotNull String toolId) {
+        if (!toolId.equals("PhpUnused")) {
+            return false;
+        }
+
+        if (isActionMethod(element)) {
+            PsiElement classParent = PsiTreeUtil.findFirstParent(element, e -> e instanceof PhpClass);
+            if (classParent == null) {
+                return false;
+            }
+
+            return isControllerPhpClass((PhpClass) classParent);
+        }
+
+        if (isControllerClassElement(element)) {
+            return isControllerPhpClass((PhpClass) element);
+        }
+
+        return false;
+    }
+
+    private boolean isControllerClassElement(@NotNull PsiElement element) {
+        return PlatformPatterns.psiElement(PhpClass.class).withName(PlatformPatterns.string().endsWith("Controller")).accepts(element);
+    }
+
+    private boolean isControllerPhpClass(PhpClass classParent) {
+
+        return PhpIndex.getInstance(classParent.getProject())
+            .getAllSubclasses("TYPO3\\CMS\\Extbase\\Mvc\\Controller\\ControllerInterface")
+            .contains(classParent);
+    }
+
+    private boolean isActionMethod(PsiElement element) {
+
+        return PlatformPatterns.psiElement(Method.class)
+            .withName(PlatformPatterns.string().endsWith("Action"))
+            .accepts(element);
+    }
+
+    @NotNull
+    @Override
+    public SuppressQuickFix[] getSuppressActions(@Nullable PsiElement element, @NotNull String toolId) {
+        return SuppressQuickFix.EMPTY_ARRAY;
+    }
+}

--- a/typo3-cms/src/main/resources/META-INF/plugin.xml
+++ b/typo3-cms/src/main/resources/META-INF/plugin.xml
@@ -254,6 +254,9 @@ It is a great inspiration for possible solutions and parts of the code.</p>
                          enabledByDefault="true" level="WARNING"
                          implementationClass="com.cedricziel.idea.typo3.codeInspection.LegacyClassesForIDEInspection"/>
 
+        <lang.inspectionSuppressor language="PHP"
+                                   implementationClass="com.cedricziel.idea.typo3.codeInspection.UnusedActionControllerMethodInspectionSuppressor"/>
+
         <psi.referenceContributor implementation="com.cedricziel.idea.typo3.icons.IconReferenceContributor"/>
         <psi.referenceContributor implementation="com.cedricziel.idea.typo3.routing.RouteReferenceContributor"/>
         <psi.referenceContributor implementation="com.cedricziel.idea.typo3.resources.ResourceReferenceContributor"/>

--- a/typo3-cms/src/test/java/com/cedricziel/idea/typo3/codeInspection/UnusedActionControllerMethodInspectionSuppressorTest.java
+++ b/typo3-cms/src/test/java/com/cedricziel/idea/typo3/codeInspection/UnusedActionControllerMethodInspectionSuppressorTest.java
@@ -1,0 +1,18 @@
+package com.cedricziel.idea.typo3.codeInspection;
+
+import com.cedricziel.idea.typo3.AbstractTestCase;
+import com.jetbrains.php.lang.inspections.deadcode.PhpUnusedDeclarationInspection;
+
+public class UnusedActionControllerMethodInspectionSuppressorTest extends AbstractTestCase {
+    @Override
+    protected String getTestDataPath() {
+        return super.getTestDataPath() + "/codeInspection";
+    }
+
+    public void testInspectionIsSuppressedInActionControllerActions() {
+        myFixture.copyFileToProject("classes.php");
+        myFixture.enableInspections(new PhpUnusedDeclarationInspection());
+
+        myFixture.testHighlighting("action_controller.php");
+    }
+}

--- a/typo3-cms/testData/com/cedricziel/idea/typo3/codeInspection/action_controller.php
+++ b/typo3-cms/testData/com/cedricziel/idea/typo3/codeInspection/action_controller.php
@@ -1,0 +1,18 @@
+<?php
+
+use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+
+class BingBongController extends ActionController {
+    public function dingDongAction()
+    {
+    }
+
+    public function <warning descr="Unused element: 'stillUnused'">stillUnused</warning>()
+    {
+    }
+}
+
+class <warning descr="Unused element: 'ClassWithSuffixOfController'">ClassWithSuffixOfController</warning> {
+    public function <warning descr="Unused element: 'fooAction'">fooAction</warning>() {
+    }
+}

--- a/typo3-cms/testData/com/cedricziel/idea/typo3/codeInspection/classes.php
+++ b/typo3-cms/testData/com/cedricziel/idea/typo3/codeInspection/classes.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace TYPO3\CMS\Core\Utility {
+    interface SingletonInterface {}
+
+    class GeneralUtility {
+        /**
+         * @param string $className name of the class to instantiate, must not be empty and not start with a backslash
+         * @param array<int,mixed> $constructorArguments Arguments for the constructor
+         * @return object the created instance
+         * @throws \InvalidArgumentException if $className is empty or starts with a backslash
+         */
+        public static function makeInstance($className, ...$constructorArguments) {}
+
+        /**
+         * Find the best service and check if it works.
+         * Returns object of the service class.
+         *
+         * @param string $serviceType Type of service (service key).
+         * @param string $serviceSubType Sub type like file extensions or similar. Defined by the service.
+         * @param mixed $excludeServiceKeys List of service keys which should be excluded in the search for a service. Array or comma list.
+         * @throws \RuntimeException
+         * @return object|string[] The service object or an array with error infos.
+         */
+        public static function makeInstanceService($serviceType, $serviceSubType = '', $excludeServiceKeys = []) {}
+    }
+}
+
+namespace TYPO3\CMS\Extbase\Object {
+    interface ObjectManagerInterface extends \TYPO3\CMS\Core\SingletonInterface
+    {
+        /**
+         * Returns a fresh or existing instance of the object specified by $objectName.
+         *
+         * @param string $objectName The name of the object to return an instance of
+         * @param array ...$constructorArguments
+         * @return object The object instance
+         */
+        public function get(string $objectName, ...$constructorArguments): object;
+
+        /**
+         * Create an instance of $className without calling its constructor
+         *
+         * @param string $className
+         * @return object
+         */
+        public function getEmptyObject(string $className): object;
+    }
+}
+
+namespace TYPO3\CMS\Core\Utility {
+    class ExtensionManagementUtility {
+        public static function addService($extKey, $serviceType, $serviceKey, $info)
+        {
+        }
+    }
+}
+
+namespace TYPO3\CMS\Core\Log {
+    class Logger {
+    }
+
+    class LogManager {
+        /**
+         * Gets a logger instance for the given name.
+         *
+         * \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Log\LogManager::class)->getLogger('main.sub.subsub');
+         *
+         * $name can also be submitted as a underscore-separated string, which will
+         * be converted to dots. This is useful to call this method with __CLASS__
+         * as parameter.
+         *
+         * @param string $name Logger name, empty to get the global "root" logger.
+         * @return \TYPO3\CMS\Core\Log\Logger Logger with name $name
+         */
+        public function getLogger($name = '') {
+        }
+    }
+}
+
+namespace TYPO3\CMS\Extbase\Mvc {
+    interface ResponseInterface {}
+    interface RequestInterface {}
+}
+
+namespace TYPO3\CMS\Extbase\Mvc\Controller {
+
+    interface ControllerInterface {}
+
+    class ActionController implements ControllerInterface {
+
+    }
+}
+
+namespace App {
+    class Apple {
+        public function tree() : ?Tree
+        {
+        }
+    }
+    class Tree {
+
+    }
+
+    class TwoArgs {
+        public function __construct(string $foo)
+        {
+        }
+    }
+}


### PR DESCRIPTION
* classes implementing ControllerInterface and
* methods in such classes with an `Action` suffix

wont be marked as unused anymore.

Closes: #291 